### PR TITLE
feat: Added ECDSA PKey validation and unit test

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -918,23 +918,6 @@ func VerifySignature(pubkey, digestHash, signature []byte) bool {
 	return pubKey.IsEqual(recoveredKey)
 }
 
-func privateKeyFromBytes(privateKey []byte) (*btcec.PrivateKey, error) {
-	if len(privateKey) != 32 {
-		return nil, fmt.Errorf("invalid private key length")
-	}
-	var allNonPositive bool = true
-	for _, v := range privateKey {
-		if v > 0 {
-			allNonPositive = false
-		}
-	}
-	if allNonPositive {
-		return nil, fmt.Errorf("invalid private key, zero or negative")
-	}
-	pk, _ := btcec.PrivKeyFromBytes(privateKey)
-	return pk, nil
-}
-
 func CompressPubkey(pubKey *secp256k1.PublicKey) []byte {
 	return pubKey.SerializeCompressed()
 }

--- a/crypto_unit_test.go
+++ b/crypto_unit_test.go
@@ -925,6 +925,12 @@ func TestUnitECDSAPublicKeyFromBytesRawInvalidKey(t *testing.T) {
 	}
 }
 
+func TestUnitECDSAPrivateKeyFromBytesRawInvalidNValue(t *testing.T) {
+	secp256k1UpperNValue := "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141"
+	_, err := _ECDSAPrivateKeyFromString(secp256k1UpperNValue)
+	require.Error(t, err)
+}
+
 func TestUnitECDSAPublicKeyFromBytesDerInvalidKey(t *testing.T) {
 	_, err := _ECDSAPublicKeyFromBytesDer(nil)
 	require.Error(t, err)

--- a/ed25519_public_key.go
+++ b/ed25519_public_key.go
@@ -46,6 +46,7 @@ func _Ed25519PublicKeyFromBytesRaw(bytes []byte) (*_Ed25519PublicKey, error) {
 	if bytes == nil {
 		return &_Ed25519PublicKey{}, errByteArrayNull
 	}
+	
 	if len(bytes) != ed25519.PublicKeySize {
 		return &_Ed25519PublicKey{}, _NewErrBadKeyf("invalid public key length: %v bytes", len(bytes))
 	}


### PR DESCRIPTION
**Description**:
This PR resolves issues for users who would potentially try to create an invalid PKey/PBKey over the Kublitz ECDSA curve.
Introducing PBKey validation as defined in issue https://github.com/hiero-ledger/hiero-sdk-go/issues/1166 could only potentially harm user input related to HIP-540 or introduce restrictions not adhering to crypto library specific generator functions.

**Related issue(s)**:

Closes relevancy for: https://github.com/hiero-ledger/hiero-sdk-go/issues/1166

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
