### PR TITLE
test: Create additional unit/integration tests

### DIFF
--- a/sdk/freeze_transaction.go
+++ b/sdk/freeze_transaction.go
@@ -27,23 +27,13 @@ func NewFreezeTransaction() *FreezeTransaction {
 }
 
 func _FreezeTransactionFromProtobuf(tx Transaction[*FreezeTransaction], pb *services.TransactionBody) FreezeTransaction {
-	startTime := time.Date(
-		time.Now().Year(), time.Now().Month(), time.Now().Day(),
-		int(pb.GetFreeze().GetStartHour()), int(pb.GetFreeze().GetStartMin()), // nolint
-		0, time.Now().Nanosecond(), time.Now().Location(),
-	)
-
-	endTime := time.Date(
-		time.Now().Year(), time.Now().Month(), time.Now().Day(),
-		int(pb.GetFreeze().GetEndHour()), int(pb.GetFreeze().GetEndMin()), // nolint
-		0, time.Now().Nanosecond(), time.Now().Location(),
-	)
+	startTime := _TimeFromProtobuf(pb.GetFreeze().GetStartTime())
 
 	freezeTransaction := FreezeTransaction{
-		startTime: startTime,
-		endTime:   endTime,
-		fileID:    _FileIDFromProtobuf(pb.GetFreeze().GetUpdateFile()),
-		fileHash:  pb.GetFreeze().FileHash,
+		startTime:  startTime,
+		fileID:     _FileIDFromProtobuf(pb.GetFreeze().GetUpdateFile()),
+		fileHash:   pb.GetFreeze().FileHash,
+		freezeType: FreezeType(pb.GetFreeze().FreezeType),
 	}
 	tx.childTransaction = &freezeTransaction
 	freezeTransaction.Transaction = &tx

--- a/sdk/freeze_transaction_unit_test.go
+++ b/sdk/freeze_transaction_unit_test.go
@@ -1,0 +1,162 @@
+//go:build all || unit
+// +build all unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitFreezeTransactionSetStartTime(t *testing.T) {
+	t.Parallel()
+
+	startTime := time.Now().Add(time.Hour)
+
+	transaction := NewFreezeTransaction().
+		SetStartTime(startTime)
+
+	require.Equal(t, transaction.GetStartTime(), startTime)
+}
+
+func TestUnitFreezeTransactionSetEndTime(t *testing.T) {
+	t.Parallel()
+
+	endTime := time.Now().Add(2 * time.Hour)
+
+	transaction := NewFreezeTransaction().
+		SetEndTime(endTime)
+
+	require.Equal(t, transaction.GetEndTime(), endTime)
+}
+
+func TestUnitFreezeTransactionSetFileID(t *testing.T) {
+	t.Parallel()
+
+	fileID := FileID{File: 1}
+
+	transaction := NewFreezeTransaction().
+		SetFileID(fileID)
+
+	require.Equal(t, transaction.GetFileID(), &fileID)
+}
+
+func TestUnitFreezeTransactionSetFreezeType(t *testing.T) {
+	t.Parallel()
+
+	freezeType := FreezeTypeFreezeOnly
+
+	transaction := NewFreezeTransaction().
+		SetFreezeType(freezeType)
+
+	require.Equal(t, transaction.GetFreezeType(), freezeType)
+}
+
+func TestUnitFreezeTransactionSetFileHash(t *testing.T) {
+	t.Parallel()
+
+	fileHash := []byte{1, 2, 3, 4, 5}
+
+	transaction := NewFreezeTransaction().
+		SetFileHash(fileHash)
+
+	require.Equal(t, transaction.GetFileHash(), fileHash)
+}
+
+func TestUnitFreezeTransactionToBytes(t *testing.T) {
+	t.Parallel()
+
+	startTime := time.Now().Add(time.Hour)
+	endTime := time.Now().Add(2 * time.Hour)
+	fileID := FileID{File: 1}
+	fileHash := []byte{1, 2, 3, 4, 5}
+	freezeType := FreezeTypeFreezeOnly
+
+	transaction := NewFreezeTransaction().
+		SetStartTime(startTime).
+		SetEndTime(endTime).
+		SetFileID(fileID).
+		SetFileHash(fileHash).
+		SetFreezeType(freezeType)
+
+	bytes, err := transaction.ToBytes()
+	require.NoError(t, err)
+	require.NotNil(t, bytes)
+}
+
+func TestUnitFreezeTransactionFromBytes(t *testing.T) {
+	t.Parallel()
+
+	startTime := time.Now().Add(time.Hour)
+	fileID := FileID{File: 1}
+	fileHash := []byte{1, 2, 3, 4, 5}
+	freezeType := FreezeTypeFreezeOnly
+
+	transaction := NewFreezeTransaction().
+		SetStartTime(startTime).
+		SetFileID(fileID).
+		SetFileHash(fileHash).
+		SetFreezeType(freezeType)
+
+	bytes, err := transaction.ToBytes()
+	require.NoError(t, err)
+	require.NotNil(t, bytes)
+
+	deserializedTransaction, err := TransactionFromBytes(bytes)
+	require.NoError(t, err)
+
+	switch tx := deserializedTransaction.(type) {
+	case FreezeTransaction:
+		assert.True(t, transaction.GetStartTime().Equal(tx.GetStartTime()))
+		assert.Equal(t, transaction.GetFileID(), tx.GetFileID())
+		assert.Equal(t, transaction.GetFileHash(), tx.GetFileHash())
+		assert.Equal(t, transaction.GetFreezeType(), tx.GetFreezeType())
+	default:
+		t.Fatalf("expected FreezeTransaction, got %T", deserializedTransaction)
+	}
+}
+
+func TestUnitFreezeTransactionScheduleProtobuf(t *testing.T) {
+	t.Parallel()
+
+	transactionID := TransactionIDGenerate(AccountID{Account: 324})
+	startTime := time.Now().Add(time.Hour)
+	endTime := time.Now().Add(2 * time.Hour)
+	fileID := FileID{File: 1}
+	fileHash := []byte{1, 2, 3, 4, 5}
+	freezeType := FreezeTypeFreezeOnly
+	nodeAccountID := []AccountID{{Account: 10}}
+
+	tx, err := NewFreezeTransaction().
+		SetTransactionID(transactionID).
+		SetNodeAccountIDs(nodeAccountID).
+		SetStartTime(startTime).
+		SetEndTime(endTime).
+		SetFileID(fileID).
+		SetFileHash(fileHash).
+		SetFreezeType(freezeType).
+		Freeze()
+	require.NoError(t, err)
+
+	expected := &services.SchedulableTransactionBody{
+		TransactionFee: 100000000,
+		Data: &services.SchedulableTransactionBody_Freeze{
+			Freeze: &services.FreezeTransactionBody{
+				StartTime:  _TimeToProtobuf(startTime),
+				UpdateFile: fileID._ToProtobuf(),
+				FileHash:   fileHash,
+				FreezeType: services.FreezeType(freezeType),
+			},
+		},
+	}
+
+	actual, err := tx.buildScheduled()
+	require.NoError(t, err)
+	require.Equal(t, expected.GetFreeze(), actual.GetFreeze())
+}

--- a/sdk/prng_transaction_e2e_test.go
+++ b/sdk/prng_transaction_e2e_test.go
@@ -1,0 +1,29 @@
+//go:build all || e2e
+// +build all e2e
+
+package hiero
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// SPDX-License-Identifier: Apache-2.0
+
+func TestIntegrationPrngTransactionCanExecute(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	rang := uint32(100)
+
+	resp, err := NewPrngTransaction().
+		SetRange(rang).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	record, err := resp.GetRecord(env.Client)
+	require.NoError(t, err)
+	require.NotNil(t, record.PrngNumber)
+}

--- a/sdk/prng_transaction_unit_test.go
+++ b/sdk/prng_transaction_unit_test.go
@@ -1,0 +1,76 @@
+//go:build all || unit
+// +build all unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"testing"
+
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitPrngTransactionSetRange(t *testing.T) {
+	t.Parallel()
+
+	rang := uint32(100)
+
+	transaction := NewPrngTransaction().
+		SetRange(rang)
+
+	require.Equal(t, transaction.GetRange(), rang)
+}
+
+func TestUnitPrngTransactionFromBytes(t *testing.T) {
+	t.Parallel()
+
+	rang := uint32(100)
+
+	transaction := NewPrngTransaction().
+		SetRange(rang)
+
+	bytes, err := transaction.ToBytes()
+	require.NoError(t, err)
+	require.NotNil(t, bytes)
+
+	deserializedTransaction, err := TransactionFromBytes(bytes)
+	require.NoError(t, err)
+
+	switch tx := deserializedTransaction.(type) {
+	case PrngTransaction:
+		assert.Equal(t, transaction.GetRange(), tx.GetRange())
+	default:
+		t.Fatalf("expected PrngTransaction, got %T", deserializedTransaction)
+	}
+}
+
+func TestUnitPrngTransactionScheduleProtobuf(t *testing.T) {
+	t.Parallel()
+
+	transactionID := TransactionIDGenerate(AccountID{Account: 324})
+	rang := uint32(100)
+	nodeAccountID := []AccountID{{Account: 10}}
+
+	tx, err := NewPrngTransaction().
+		SetTransactionID(transactionID).
+		SetNodeAccountIDs(nodeAccountID).
+		SetRange(rang).
+		Freeze()
+	require.NoError(t, err)
+
+	expected := &services.SchedulableTransactionBody{
+		TransactionFee: 100000000,
+		Data: &services.SchedulableTransactionBody_UtilPrng{
+			UtilPrng: &services.UtilPrngTransactionBody{
+				Range: int32(rang),
+			},
+		},
+	}
+
+	actual, err := tx.buildScheduled()
+	require.NoError(t, err)
+	require.Equal(t, expected.GetUtilPrng(), actual.GetUtilPrng())
+}


### PR DESCRIPTION
This PR add unit/integration tests for `PrngTransaction` and `FreezeTransaction` and fixes a bug in `FreezeTransaction` where `protobufFromBytes` does not map the correct start time.

fixes: https://github.com/hiero-ledger/hiero-sdk-go/issues/1084