### PR TITLE
feat: `TokenRejectFlow` refactor

### DIFF
--- a/examples/token_reject/main.go
+++ b/examples/token_reject/main.go
@@ -140,19 +140,23 @@ func main() {
 		SetOwnerID(receiver).
 		SetTokenIDs(tokenID).
 		FreezeWith(client)
-	reject, _ := frozenReject.Sign(receiverKey).Execute(client)
-	receipt, err = reject.SetValidateStatus(true).GetReceipt(client)
+	resp, _ := frozenReject.Sign(receiverKey).Execute(client)
+	receipt, err = resp.SetValidateStatus(true).GetReceipt(client)
 	if err != nil {
 		panic(fmt.Sprintf("%v : Error rejecting tokens", err))
 	}
 
-	// reject the NFTs
-	frozenRejectFlow, _ := hiero.NewTokenRejectFlow().
+	tokenRejectFlow := hiero.NewTokenRejectFlow().
 		SetOwnerID(receiver).
-		SetNftIDs(nftID.Nft(serials[0]), nftID.Nft(serials[1]), nftID.Nft(serials[2])).
-		FreezeWith(client)
-	reject, _ = frozenRejectFlow.Sign(receiverKey).Execute(client)
-	receipt, err = reject.SetValidateStatus(true).GetReceipt(client)
+		SetNftIDs(nftID.Nft(serials[0]), nftID.Nft(serials[1]), nftID.Nft(serials[2]))
+
+	tokenRejectFlow.TokenRejectTransaction.SetTransactionMemo("Rejecting NFTs")
+	tokenRejectFlow.TokenDissociateTransaction.SetTransactionMemo("Dissociating NFTs")
+
+	// reject the NFTs
+	frozenRejectFlow, _ := tokenRejectFlow.FreezeWith(client)
+	resp, _ = frozenRejectFlow.Sign(receiverKey).Execute(client)
+	receipt, err = resp.SetValidateStatus(true).GetReceipt(client)
 	if err != nil {
 		panic(fmt.Sprintf("%v : Error rejecting tokens", err))
 	}

--- a/sdk/token_reject_transaction.go
+++ b/sdk/token_reject_transaction.go
@@ -33,6 +33,7 @@ type TokenRejectTransaction struct {
 func NewTokenRejectTransaction() *TokenRejectTransaction {
 	tx := &TokenRejectTransaction{}
 	tx.Transaction = _NewTransaction(tx)
+	tx._SetDefaultMaxTransactionFee(NewHbar(2))
 	return tx
 }
 


### PR DESCRIPTION
### Description
Currently, the `TokenRejectFlow` class and similar transaction flows are overly reliant on class hierarchies that treat flows as if they are transactions themselves. This design complicates the implementation and maintenance of transaction flows.  

This PR does not change the API, but only adds getters to allow modification to the individual transactions.