### PR TITLE
fix: Add `transactionFee` in serialize/deserialize when tx is not frozen

### DIFF
--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -194,6 +194,8 @@ func TransactionFromBytes(data []byte) (TransactionInterface, error) { // nolint
 			nodeAccountID = *_AccountIDFromProtobuf(body.GetNodeAccountID())
 		}
 
+		baseTx.transactionFee = body.GetTransactionFee()
+
 		// If the transaction was serialised, without setting "NodeId", or "TransactionID", we should leave them empty
 		if transactionID.AccountID.Account != 0 {
 			baseTx.transactionIDs = baseTx.transactionIDs._Push(transactionID)
@@ -665,6 +667,13 @@ func (tx *Transaction[T]) buildUnsignedTransaction(index int) (*services.Transac
 	if body.NodeAccountID == nil && !tx.nodeAccountIDs._IsEmpty() {
 		body.NodeAccountID = tx.nodeAccountIDs._Get(index).(AccountID)._ToProtobuf()
 	}
+	var transactionFee uint64
+	if tx.transactionFee != 0 {
+		transactionFee = tx.transactionFee
+	} else {
+		transactionFee = tx.defaultMaxTransactionFee
+	}
+	body.TransactionFee = transactionFee
 
 	bodyBytes, err := protobuf.Marshal(body)
 	if err != nil {

--- a/sdk/utilities_for_test.go
+++ b/sdk/utilities_for_test.go
@@ -95,7 +95,6 @@ func NewIntegrationTestEnv(t *testing.T) IntegrationTestEnv {
 	env.Client.SetNodeMinReadmitPeriod(5 * time.Second)
 	env.Client.SetNodeMaxReadmitPeriod(1 * time.Hour)
 	env.Client.SetMaxAttempts(15)
-	env.Client.SetDefaultMaxTransactionFee(NewHbar(50))
 	env.Client.SetDefaultMaxQueryPayment(NewHbar(50))
 	logger := NewLogger("Hiero sdk", LoggerLevelError)
 	env.Client.SetLogger(logger)


### PR DESCRIPTION
This PR fixes a bug where `transactionFee` gets zeroed when a transaction is serialized (.toBytes) and not frozen beforehand.

This causes the transaction to fail with `INVALID_TX_FEE`. This could be reproduced with removing the default max fee from the test env client - the executable sets `transactionFee` from the client, if it's missing in the transaction body.