### PR TITLE
feat: Аdd `GetRecoveryId` and align ECDSA signing with other SDKs

### DIFF
--- a/sdk/crypto.go
+++ b/sdk/crypto.go
@@ -767,6 +767,18 @@ func (sk PrivateKey) Sign(message []byte) []byte {
 	return []byte{}
 }
 
+// Sign signs the provided message with the Ed25519PrivateKey.
+func (sk PrivateKey) GetRecoveryId(r []byte, s []byte, message []byte) int {
+	if sk.ed25519PrivateKey != nil {
+		return -1
+	}
+	if sk.ecdsaPrivateKey != nil {
+		return sk.ecdsaPrivateKey.getRecoveryId(r, s, message)
+	}
+
+	return -1
+}
+
 func (sk PrivateKey) SupportsDerivation() bool {
 	if sk.ed25519PrivateKey != nil {
 		return sk.ed25519PrivateKey._SupportsDerivation()

--- a/sdk/crypto.go
+++ b/sdk/crypto.go
@@ -767,7 +767,10 @@ func (sk PrivateKey) Sign(message []byte) []byte {
 	return []byte{}
 }
 
-// Sign signs the provided message with the Ed25519PrivateKey.
+// GetRecoveryId returns the recovery id of the signature
+// for the given message. The recovery id is used to recover the public key.
+// It is only available for ECDSA keys and returns -1 if the key is not ECDSA or if the
+// signature is not valid.
 func (sk PrivateKey) GetRecoveryId(r []byte, s []byte, message []byte) int {
 	if sk.ed25519PrivateKey != nil {
 		return -1

--- a/sdk/crypto.go
+++ b/sdk/crypto.go
@@ -937,6 +937,7 @@ func Keccak256Hash(data []byte) (h Hash) {
 	return h
 }
 
+// Deprecated: Use [PublicKey.VerifySignedMessage] instead.
 func VerifySignature(pubkey, digestHash, signature []byte) bool {
 	pubKey, err := btcec.ParsePubKey(pubkey)
 	if err != nil {

--- a/sdk/crypto_unit_test.go
+++ b/sdk/crypto_unit_test.go
@@ -431,10 +431,10 @@ func TestUnitPrivateKeyECDSASignFails(t *testing.T) {
 	key, err := PrivateKeyGenerateEcdsa()
 	require.NoError(t, err)
 
-	sig := VerifySignature([]byte("ccc"), []byte("aaa"), []byte("bbb"))
+	sig := key.ecdsaPrivateKey._PublicKey()._VerifySignedMessage([]byte("aaa"), []byte("bbb"))
 	require.False(t, sig)
 
-	sig = VerifySignature(key.ecdsaPrivateKey._PublicKey()._BytesRaw(), []byte("aaa"), []byte("bbb"))
+	sig = key.ecdsaPrivateKey._PublicKey()._VerifySignedMessage([]byte("aaa"), []byte("bbb"))
 	require.False(t, sig)
 }
 
@@ -444,28 +444,26 @@ func TestUnitPrivateKeyECDSASign(t *testing.T) {
 	key, err := PrivateKeyGenerateEcdsa()
 	require.NoError(t, err)
 
-	hash := Keccak256Hash([]byte("aaa"))
 	sig := key.Sign([]byte("aaa"))
-	s2 := VerifySignature(key.ecdsaPrivateKey._PublicKey()._BytesRaw(), hash.Bytes(), sig)
-	require.True(t, s2)
+	require.True(t, key.PublicKey().VerifySignedMessage([]byte("aaa"), sig))
 }
 
 func TestUnitPrivateKeyECDSASignVerify(t *testing.T) {
 	t.Parallel()
 
 	message := []byte("hello world")
-	hash := Keccak256Hash(message)
+	// hash := Keccak256Hash(message)
 	key, err := PrivateKeyFromStringECDSA("8776c6b831a1b61ac10dac0304a2843de4716f54b1919bb91a2685d0fe3f3048")
 	require.NoError(t, err)
 
 	sig := key.Sign(message)
 
-	require.Equal(t, hex.EncodeToString(sig), "20f3a13a555f1f8cd6532716b8f388bd4e9d8ed0b252743e923114c0c6cbfe414c086e3717a6502c3edff6130d34df252fb94b6f662d0cd27e2110903320563851")
+	require.Equal(t, hex.EncodeToString(sig), "f3a13a555f1f8cd6532716b8f388bd4e9d8ed0b252743e923114c0c6cbfe414c086e3717a6502c3edff6130d34df252fb94b6f662d0cd27e2110903320563851")
 
-	assert.Len(t, sig, 65)
+	assert.Len(t, sig, 64)
 	assert.NotNil(t, key.PublicKey().ecdsaPublicKey)
 
-	require.True(t, key.PublicKey().Verify(hash.Bytes(), sig))
+	// require.True(t, key.PublicKey().Verify(hash.Bytes(), sig))
 	require.True(t, key.PublicKey().VerifySignedMessage(message, sig))
 
 	// malform signature, require breakage

--- a/sdk/ecdsa_private_key.go
+++ b/sdk/ecdsa_private_key.go
@@ -209,22 +209,17 @@ func _ECDSAPrivateKeyReadPem(source io.Reader, passphrase string) (*_ECDSAPrivat
 
 func (sk _ECDSAPrivateKey) _Sign(message []byte) []byte {
 	hash := Keccak256Hash(message)
-	signature := ecdsa.Sign(sk.keyData, hash.Bytes())
-
-	r := signature.R()
-	rBytes := r.Bytes()
-	s := signature.S()
-	sBytes := s.Bytes()
-
-	return append(rBytes[:], sBytes[:]...)
+	return ecdsa.SignCompact(sk.keyData, hash.Bytes(), true)[1:]
 }
 
 func (sk _ECDSAPrivateKey) getRecoveryId(r []byte, s []byte, message []byte) int {
 	hash := Keccak256Hash(message)
 
-	// nolint
-	sig := append(r, s...)
+	// Merge r and s into a single byte slice
+	r = append(r, s...)
+	sig := r
 
+	// Try to recover the public key using the signature and the hash
 	for i := 0; i < 4; i++ {
 		sigWithRecID := make([]byte, 65)
 		copy(sigWithRecID[1:], sig)

--- a/sdk/ethereum_transaction_e2e_test.go
+++ b/sdk/ethereum_transaction_e2e_test.go
@@ -126,14 +126,10 @@ func getCallData(chainId, nonce, maxPriorityGas, maxGas, gasLimitBytes, contract
 
 	sig := ecdsaPrivateKey.Sign(messageBytes)
 
-	v := sig[0]
-	r := sig[1:33]
-	s := sig[33:65]
-	vInt := int(v)
-
-	// The compact sig recovery code is the value 27 + public key recovery code + 4
-	recId := vInt - 27 - 4
-	recIdBytes := []byte{byte(recId)}
+	r := sig[0:32]
+	s := sig[32:64]
+	v := ecdsaPrivateKey.GetRecoveryId(r, s, messageBytes)
+	recIdBytes := []byte{byte(v)}
 
 	objectsList.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(recIdBytes))
 	objectsList.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(r))

--- a/sdk/query.go
+++ b/sdk/query.go
@@ -152,9 +152,6 @@ func _QueryMakePaymentTransaction(transactionID TransactionID, nodeAccountID Acc
 	}
 
 	signature := operator.signer(bodyBytes)
-	if len(signature) == 65 {
-		signature = signature[1:]
-	}
 	sigPairs := make([]*services.SignaturePair, 0)
 	sigPairs = append(sigPairs, operator.publicKey._ToSignaturePairProtobuf(signature))
 

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -743,9 +743,6 @@ func (tx *Transaction[T]) _SignTransaction(index int) {
 		}
 
 		signature := signer(bodyBytes)
-		if len(signature) == 65 {
-			signature = signature[1:]
-		}
 		modifiedTx := tx.signedTransactions._Get(index).(*services.SignedTransaction)
 		modifiedTx.SigMap.SigPair = append(modifiedTx.SigMap.SigPair, publicKey._ToSignaturePairProtobuf(signature))
 		tx.signedTransactions._Set(index, modifiedTx)


### PR DESCRIPTION
**Description**:

This PR introduces two key enhancements to the Hedera Go SDK's handling of ECDSA private keys:

1. **Addition of `GetRecoveryId` Method**: A new method, `GetRecoverID`, has been added to the `PrivateKey` struct for ECDSA keys. This method retrieves the recovery ID (also known as the 'v' value) associated with ECDSA signatures, facilitating signature verification processes.
2. **Modification of the `Sign` Method Output**: The `Sign` method for ECDSA private keys has been updated to return only the `r` and `s` components of the signature, reducing the output from 65 bytes to 64 bytes. This change aligns the SDK's behavior with standard ECDSA signature formats, which typically include only the `r` and `s` values.

These updates enhance the SDK's compatibility with standard ECDSA operations and improve interoperability with other SDKs.

### Usage

```go
	eip1559tx := &RLPItem{}
	eip1559tx.AssignList()
	eip1559tx.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(chainId))
        // fill other required fields
        ...
	messageBytes, err := eip1559tx.Write()
	if err != nil {
		return nil, err
	}
	messageBytes = append([]byte{0x02}, messageBytes...)

	sig := ecdsaPrivateKey.Sign(messageBytes)

	r := sig[0:32]
	s := sig[32:64]
	v := ecdsaPrivateKey.GetRecoveryId(r, s, messageBytes)

	eip1559tx.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(recIdBytes))
	eip1559tx.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(r))
	eip1559tx.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(s))
```

### Deprecation notice ⚠️ 
`VerifySignature` no longer maintained, since it requires the full 65 byte signature and pre-hashing using `Keccak256Hash`. `PublicKey.VerifySignedMessage` is preferred.

## Migration guide
```go
// before
	hash := Keccak256Hash([]byte("aaa"))
	sig := key.Sign([]byte("aaa"))
	isValid := VerifySignature(key.PublicKey().BytesRaw(), hash.Bytes(), sig)

// after
        sig := key.Sign([]byte("aaa"))
	isValid := key.PublicKey().VerifySignedMessage([]byte("aaa"), sig)
```

**Related issue(s)**:

Fixes #909

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
