### PR TITLE
chore(fix): Make `AccountUpdateTransaction` fields optional & fix EVM address test

### DIFF
--- a/sdk/account_id.go
+++ b/sdk/account_id.go
@@ -70,6 +70,16 @@ func AccountIDFromString(data string) (AccountID, error) {
 
 // AccountIDFromEvmAddress constructs an AccountID from a string formatted as 0.0.<evm address>
 func AccountIDFromEvmAddress(shard uint64, realm uint64, aliasEvmAddress string) (AccountID, error) {
+	// Remove 0x prefix if present
+	if strings.HasPrefix(aliasEvmAddress, "0x") {
+		aliasEvmAddress = aliasEvmAddress[2:]
+	}
+
+	// Check if the address is the correct length (40 hex characters = 20 bytes)
+	if len(aliasEvmAddress) != 40 {
+		return AccountID{}, fmt.Errorf("input EVM address string is not the correct size")
+	}
+
 	temp, err := hex.DecodeString(aliasEvmAddress)
 	if err != nil {
 		return AccountID{}, err

--- a/sdk/account_id_unit_test.go
+++ b/sdk/account_id_unit_test.go
@@ -6,9 +6,12 @@ package hiero
 // SPDX-License-Identifier: Apache-2.0
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"encoding/hex"
 
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +30,7 @@ func TestUnitAccountIDChecksumFromString(t *testing.T) {
 	AccountIDFromSolidityAddress(sol)
 	err = id.Validate(client)
 	require.Error(t, err)
-	evmID, err := AccountIDFromEvmAddress(0, 0, "ace082947b949651c703ff0f02bc1541")
+	evmID, err := AccountIDFromEvmAddress(0, 0, "0x742d35Cc6634C0532925a3b844Bc454e4438f44e")
 	require.NoError(t, err)
 	pb := evmID._ToProtobuf()
 	_AccountIDFromProtobuf(pb)
@@ -173,4 +176,31 @@ func TestUnitAccountIDChecksumError(t *testing.T) {
 	require.NoError(t, err)
 	_, err = id.ToStringWithChecksum(client)
 	require.Error(t, err)
+}
+
+func TestUnitAccountIDFromEvmAddressIncorrectSize(t *testing.T) {
+	t.Parallel()
+
+	// Test with an EVM address that's too short
+	_, err := AccountIDFromEvmAddress(0, 0, "abc123")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "input EVM address string is not the correct size")
+
+	// Test with an EVM address that's too long
+	_, err = AccountIDFromEvmAddress(0, 0, "0123456789abcdef0123456789abcdef0123456789abcdef")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "input EVM address string is not the correct size")
+
+	// Test with a 0x prefix that gets removed but then is too short
+	_, err = AccountIDFromEvmAddress(0, 0, "0xabc123")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "input EVM address string is not the correct size")
+
+	// Verify a correct length works
+	correctAddress := "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+	id, err := AccountIDFromEvmAddress(0, 0, correctAddress)
+	require.NoError(t, err)
+	require.NotNil(t, id.AliasEvmAddress)
+
+	require.Equal(t, strings.ToLower("742d35Cc6634C0532925a3b844Bc454e4438f44e"), hex.EncodeToString(*id.AliasEvmAddress))
 }

--- a/sdk/account_update_transaction_e2e_test.go
+++ b/sdk/account_update_transaction_e2e_test.go
@@ -166,5 +166,272 @@ func TestIntegrationAccountUpdateTransactionAccountIDNotSet(t *testing.T) {
 	if err != nil {
 		assert.Contains(t, err.Error(), "exceptional precheck status ACCOUNT_ID_DOES_NOT_EXIST")
 	}
+}
 
+func TestIntegrationAccountUpdateOptionalFields(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	// Create a new account
+	newKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	newBalance := NewHbar(2)
+
+	resp, err := NewAccountCreateTransaction().
+		SetKeyWithoutAlias(newKey.PublicKey()).
+		SetNodeAccountIDs(env.NodeAccountIDs).
+		SetInitialBalance(newBalance).
+		Execute(env.Client)
+
+	require.NoError(t, err)
+
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	accountID := *receipt.AccountID
+
+	// Test setting the optional fields
+	testMemo := "test memo"
+	maxTokens := int32(100)
+	declineReward := true
+
+	tx, err := NewAccountUpdateTransaction().
+		SetAccountID(accountID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		SetAccountMemo(testMemo).
+		SetMaxAutomaticTokenAssociations(maxTokens).
+		SetDeclineStakingReward(declineReward).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	tx.Sign(newKey)
+
+	resp, err = tx.Execute(env.Client)
+	require.NoError(t, err)
+
+	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	// Verify the account was updated correctly
+	info, err := NewAccountInfoQuery().
+		SetAccountID(accountID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	assert.Equal(t, testMemo, info.AccountMemo)
+	assert.Equal(t, maxTokens, int32(info.MaxAutomaticTokenAssociations))
+	assert.Equal(t, declineReward, info.StakingInfo.DeclineStakingReward)
+
+	// Test setting to zero/empty values
+	emptyMemo := ""
+	zeroTokens := int32(0)
+	acceptReward := false
+
+	tx, err = NewAccountUpdateTransaction().
+		SetAccountID(accountID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		SetAccountMemo(emptyMemo).
+		SetMaxAutomaticTokenAssociations(zeroTokens).
+		SetDeclineStakingReward(acceptReward).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	tx.Sign(newKey)
+
+	resp, err = tx.Execute(env.Client)
+	require.NoError(t, err)
+
+	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	// Verify the account was updated correctly with zero/empty values
+	info, err = NewAccountInfoQuery().
+		SetAccountID(accountID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	assert.Equal(t, emptyMemo, info.AccountMemo)
+	assert.Equal(t, zeroTokens, int32(info.MaxAutomaticTokenAssociations))
+	assert.Equal(t, acceptReward, info.StakingInfo.DeclineStakingReward)
+
+	// Clean up by deleting the test account
+	txDelete, err := NewAccountDeleteTransaction().
+		SetAccountID(accountID).
+		SetTransferAccountID(env.Client.GetOperatorAccountID()).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	txDelete.Sign(newKey)
+
+	resp, err = txDelete.Execute(env.Client)
+	require.NoError(t, err)
+
+	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+}
+
+func TestIntegrationAccountUpdateSelectiveFieldChanges(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	// Create a new account
+	newKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	newBalance := NewHbar(2)
+
+	resp, err := NewAccountCreateTransaction().
+		SetKeyWithoutAlias(newKey.PublicKey()).
+		SetNodeAccountIDs(env.NodeAccountIDs).
+		SetInitialBalance(newBalance).
+		Execute(env.Client)
+
+	require.NoError(t, err)
+
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	accountID := *receipt.AccountID
+
+	// Set initial values for all fields
+	initialMemo := "initial memo"
+	initialMaxTokens := int32(100)
+	initialDeclineReward := false
+
+	tx, err := NewAccountUpdateTransaction().
+		SetAccountID(accountID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		SetAccountMemo(initialMemo).
+		SetMaxAutomaticTokenAssociations(initialMaxTokens).
+		SetDeclineStakingReward(initialDeclineReward).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	tx.Sign(newKey)
+
+	resp, err = tx.Execute(env.Client)
+	require.NoError(t, err)
+
+	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	// Verify initial values
+	info, err := NewAccountInfoQuery().
+		SetAccountID(accountID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	assert.Equal(t, initialMemo, info.AccountMemo)
+	assert.Equal(t, initialMaxTokens, int32(info.MaxAutomaticTokenAssociations))
+	assert.Equal(t, initialDeclineReward, info.StakingInfo.DeclineStakingReward)
+
+	// Test 1: Update ONLY memo, verify others unchanged
+	updatedMemo := "updated memo"
+
+	tx, err = NewAccountUpdateTransaction().
+		SetAccountID(accountID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		SetAccountMemo(updatedMemo).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	tx.Sign(newKey)
+
+	resp, err = tx.Execute(env.Client)
+	require.NoError(t, err)
+
+	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	// Verify only memo changed
+	info, err = NewAccountInfoQuery().
+		SetAccountID(accountID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	assert.Equal(t, updatedMemo, info.AccountMemo)                               // Updated
+	assert.Equal(t, initialMaxTokens, int32(info.MaxAutomaticTokenAssociations)) // Unchanged
+	assert.Equal(t, initialDeclineReward, info.StakingInfo.DeclineStakingReward) // Unchanged
+
+	// Test 2: Update ONLY maxAutomaticTokenAssociations, verify others unchanged
+	updatedMaxTokens := int32(50)
+
+	tx, err = NewAccountUpdateTransaction().
+		SetAccountID(accountID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		SetMaxAutomaticTokenAssociations(updatedMaxTokens).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	tx.Sign(newKey)
+
+	resp, err = tx.Execute(env.Client)
+	require.NoError(t, err)
+
+	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	// Verify only maxAutomaticTokenAssociations changed
+	info, err = NewAccountInfoQuery().
+		SetAccountID(accountID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	assert.Equal(t, updatedMemo, info.AccountMemo)                               // Unchanged from last update
+	assert.Equal(t, updatedMaxTokens, int32(info.MaxAutomaticTokenAssociations)) // Updated
+	assert.Equal(t, initialDeclineReward, info.StakingInfo.DeclineStakingReward) // Unchanged
+
+	// Test 3: Update ONLY declineReward, verify others unchanged
+	updatedDeclineReward := true
+
+	tx, err = NewAccountUpdateTransaction().
+		SetAccountID(accountID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		SetDeclineStakingReward(updatedDeclineReward).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	tx.Sign(newKey)
+
+	resp, err = tx.Execute(env.Client)
+	require.NoError(t, err)
+
+	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	// Verify only declineReward changed
+	info, err = NewAccountInfoQuery().
+		SetAccountID(accountID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	assert.Equal(t, updatedMemo, info.AccountMemo)                               // Unchanged from last update
+	assert.Equal(t, updatedMaxTokens, int32(info.MaxAutomaticTokenAssociations)) // Unchanged from last update
+	assert.Equal(t, updatedDeclineReward, info.StakingInfo.DeclineStakingReward) // Updated
+
+	// Clean up by deleting the test account
+	txDelete, err := NewAccountDeleteTransaction().
+		SetAccountID(accountID).
+		SetTransferAccountID(env.Client.GetOperatorAccountID()).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	txDelete.Sign(newKey)
+
+	resp, err = txDelete.Execute(env.Client)
+	require.NoError(t, err)
+
+	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
**Description**:
This PR made `memo`, `declineReward`, and `maxAutomaticTokenAssociations` fields optional in `AccountUpdateTransaction` by converting them to pointers with nil checks. Fixed EVM address from string method and changed the tests to properly handle 0x prefix in hex comparison. Added end-to-end tests verifying that fields are only updated when explicitly set.

**Related issue(s)**:
#1288 

**Checklist**
- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
