### PR TITLE
feat: Non-Zero Realm and Shard File IDs for Static Files

### DIFF
--- a/sdk/address_book_query.go
+++ b/sdk/address_book_query.go
@@ -104,7 +104,12 @@ func (q *AddressBookQuery) Execute(client *Client) (NodeAddressBook, error) {
 
 	messages := make([]*services.NodeAddress, 0)
 
-	channel, err := client.mirrorNetwork._GetNextMirrorNode()._GetNetworkServiceClient()
+	mirrorNode, err := client.mirrorNetwork._GetNextMirrorNode()
+	if err != nil {
+		return NodeAddressBook{}, err
+	}
+
+	channel, err := mirrorNode._GetNetworkServiceClient()
 	if err != nil {
 		return NodeAddressBook{}, err
 	}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -65,10 +65,23 @@ var previewnetMirror = []string{"previewnet.mirrornode.hedera.com:443"}
 
 // ClientForMirrorNetwork constructs a client given a set of mirror network nodes.
 func ClientForMirrorNetwork(mirrorNetwork []string) (*Client, error) {
+	return ClientForMirrorNetworkWithRealmAndShard(mirrorNetwork, 0, 0)
+}
+
+// ClientForMirrorNetworkWithRealmAndShard constructs a client given a set of mirror network nodes and the realm/shard of the address book.
+func ClientForMirrorNetworkWithRealmAndShard(mirrorNetwork []string, realm int64, shard int64) (*Client, error) {
+	if realm < 0 || shard < 0 {
+		return nil, fmt.Errorf("realm and shard must be non-negative")
+	}
+
 	net := _NewNetwork()
 	client := _NewClient(net, mirrorNetwork, nil, true)
+	addressbookFileID, err := GetAddressBookFileIDFor(realm, shard)
+	if err != nil {
+		return nil, err
+	}
 	addressbook, err := NewAddressBookQuery().
-		SetFileID(FileIDForAddressBook()).
+		SetFileID(addressbookFileID).
 		Execute(client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query address book: %v", err)

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -69,19 +69,11 @@ func ClientForMirrorNetwork(mirrorNetwork []string) (*Client, error) {
 }
 
 // ClientForMirrorNetworkWithRealmAndShard constructs a client given a set of mirror network nodes and the realm/shard of the address book.
-func ClientForMirrorNetworkWithRealmAndShard(mirrorNetwork []string, realm int64, shard int64) (*Client, error) {
-	if realm < 0 || shard < 0 {
-		return nil, fmt.Errorf("realm and shard must be non-negative")
-	}
-
+func ClientForMirrorNetworkWithRealmAndShard(mirrorNetwork []string, realm uint64, shard uint64) (*Client, error) {
 	net := _NewNetwork()
 	client := _NewClient(net, mirrorNetwork, nil, true)
-	addressbookFileID, err := GetAddressBookFileIDFor(realm, shard)
-	if err != nil {
-		return nil, err
-	}
 	addressbook, err := NewAddressBookQuery().
-		SetFileID(addressbookFileID).
+		SetFileID(GetAddressBookFileIDFor(realm, shard)).
 		Execute(client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query address book: %v", err)

--- a/sdk/client_e2e_test.go
+++ b/sdk/client_e2e_test.go
@@ -132,4 +132,45 @@ func TestClientInitWithMirrorNetwork(t *testing.T) {
 	assert.Equal(t, 1, len(mirrorNetwork))
 	assert.Equal(t, mirrorNetworkString, mirrorNetwork[0])
 	assert.NotEmpty(t, client.GetNetwork())
+
+	client, err = ClientForMirrorNetworkWithRealmAndShard([]string{mirrorNetworkString}, 0, 0)
+	require.NoError(t, err)
+
+	mirrorNetwork = client.GetMirrorNetwork()
+	assert.Equal(t, 1, len(mirrorNetwork))
+	assert.Equal(t, mirrorNetworkString, mirrorNetwork[0])
+	assert.NotEmpty(t, client.GetNetwork())
+}
+
+func TestClientForMirrorNetworkWithRealmAndShard(t *testing.T) {
+	t.Parallel()
+
+	mirrorNetworkString := "testnet.mirrornode.hedera.com:443"
+	client, err := ClientForMirrorNetworkWithRealmAndShard([]string{mirrorNetworkString}, 0, 0)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	// TODO enable when we have non-zero realm and shard env
+	// client, err = ClientForMirrorNetworkWithRealmAndShard([]string{mirrorNetworkString}, 5, 3)
+	// require.NoError(t, err)
+	// require.NotNil(t, client)
+
+	client, err = ClientForMirrorNetworkWithRealmAndShard([]string{mirrorNetworkString}, -1, 0)
+	require.Error(t, err)
+	require.Nil(t, client)
+	assert.Contains(t, err.Error(), "realm and shard must be non-negative")
+
+	client, err = ClientForMirrorNetworkWithRealmAndShard([]string{mirrorNetworkString}, 0, -1)
+	require.Error(t, err)
+	require.Nil(t, client)
+	assert.Contains(t, err.Error(), "realm and shard must be non-negative")
+
+	client, err = ClientForMirrorNetworkWithRealmAndShard([]string{mirrorNetworkString}, -1, -1)
+	require.Error(t, err)
+	require.Nil(t, client)
+	assert.Contains(t, err.Error(), "realm and shard must be non-negative")
+
+	client, err = ClientForMirrorNetworkWithRealmAndShard([]string{}, 0, 0)
+	require.Nil(t, client)
+	assert.Contains(t, err.Error(), "failed to query address book: no healthy nodes")
 }

--- a/sdk/client_e2e_test.go
+++ b/sdk/client_e2e_test.go
@@ -155,21 +155,6 @@ func TestClientForMirrorNetworkWithRealmAndShard(t *testing.T) {
 	// require.NoError(t, err)
 	// require.NotNil(t, client)
 
-	client, err = ClientForMirrorNetworkWithRealmAndShard([]string{mirrorNetworkString}, -1, 0)
-	require.Error(t, err)
-	require.Nil(t, client)
-	assert.Contains(t, err.Error(), "realm and shard must be non-negative")
-
-	client, err = ClientForMirrorNetworkWithRealmAndShard([]string{mirrorNetworkString}, 0, -1)
-	require.Error(t, err)
-	require.Nil(t, client)
-	assert.Contains(t, err.Error(), "realm and shard must be non-negative")
-
-	client, err = ClientForMirrorNetworkWithRealmAndShard([]string{mirrorNetworkString}, -1, -1)
-	require.Error(t, err)
-	require.Nil(t, client)
-	assert.Contains(t, err.Error(), "realm and shard must be non-negative")
-
 	client, err = ClientForMirrorNetworkWithRealmAndShard([]string{}, 0, 0)
 	require.Nil(t, client)
 	assert.Contains(t, err.Error(), "failed to query address book: no healthy nodes")

--- a/sdk/file_id.go
+++ b/sdk/file_id.go
@@ -34,39 +34,30 @@ func FileIDForExchangeRate() FileID {
 }
 
 // GetAddressBookFileIDFor returns the public node address book FileID for the given realm and shard.
-func GetAddressBookFileIDFor(realm int64, shard int64) (FileID, error) {
-	if realm < 0 || shard < 0 {
-		return FileID{}, errors.New("realm and shard must be non-negative")
-	}
+func GetAddressBookFileIDFor(realm uint64, shard uint64) FileID {
 	return FileID{
-		Shard: uint64(shard),
-		Realm: uint64(realm),
+		Shard: shard,
+		Realm: realm,
 		File:  102,
-	}, nil
+	}
 }
 
 // GetFeeScheduleFileIDFor returns the fee schedule FileID for the given realm and shard.
-func GetFeeScheduleFileIDFor(realm int64, shard int64) (FileID, error) {
-	if realm < 0 || shard < 0 {
-		return FileID{}, errors.New("realm and shard must be non-negative")
-	}
+func GetFeeScheduleFileIDFor(realm uint64, shard uint64) FileID {
 	return FileID{
-		Shard: uint64(shard),
-		Realm: uint64(realm),
+		Shard: shard,
+		Realm: realm,
 		File:  111,
-	}, nil
+	}
 }
 
 // GetExchangeRatesFileIDFor returns the exchange rates FileID for the given realm and shard.
-func GetExchangeRatesFileIDFor(realm int64, shard int64) (FileID, error) {
-	if realm < 0 || shard < 0 {
-		return FileID{}, errors.New("realm and shard must be non-negative")
-	}
+func GetExchangeRatesFileIDFor(realm uint64, shard uint64) FileID {
 	return FileID{
-		Shard: uint64(shard),
-		Realm: uint64(realm),
+		Shard: shard,
+		Realm: realm,
 		File:  112,
-	}, nil
+	}
 }
 
 // FileIDFromString returns a FileID parsed from the given string.

--- a/sdk/file_id.go
+++ b/sdk/file_id.go
@@ -33,6 +33,42 @@ func FileIDForExchangeRate() FileID {
 	return FileID{File: 112}
 }
 
+// GetAddressBookFileIDFor returns the public node address book FileID for the given realm and shard.
+func GetAddressBookFileIDFor(realm int64, shard int64) (FileID, error) {
+	if realm < 0 || shard < 0 {
+		return FileID{}, errors.New("realm and shard must be non-negative")
+	}
+	return FileID{
+		Shard: uint64(shard),
+		Realm: uint64(realm),
+		File:  102,
+	}, nil
+}
+
+// GetFeeScheduleFileIDFor returns the fee schedule FileID for the given realm and shard.
+func GetFeeScheduleFileIDFor(realm int64, shard int64) (FileID, error) {
+	if realm < 0 || shard < 0 {
+		return FileID{}, errors.New("realm and shard must be non-negative")
+	}
+	return FileID{
+		Shard: uint64(shard),
+		Realm: uint64(realm),
+		File:  111,
+	}, nil
+}
+
+// GetExchangeRatesFileIDFor returns the exchange rates FileID for the given realm and shard.
+func GetExchangeRatesFileIDFor(realm int64, shard int64) (FileID, error) {
+	if realm < 0 || shard < 0 {
+		return FileID{}, errors.New("realm and shard must be non-negative")
+	}
+	return FileID{
+		Shard: uint64(shard),
+		Realm: uint64(realm),
+		File:  112,
+	}, nil
+}
+
 // FileIDFromString returns a FileID parsed from the given string.
 // A malformatted string will cause this to return an error instead.
 func FileIDFromString(data string) (FileID, error) {

--- a/sdk/file_id_unit_test.go
+++ b/sdk/file_id_unit_test.go
@@ -61,3 +61,75 @@ func TestUnitFileIDChecksumError(t *testing.T) {
 	_, err = id.ToStringWithChecksum(*client)
 	require.Error(t, err)
 }
+
+func TestUnitGetAddressBookFileIDFor(t *testing.T) {
+	t.Parallel()
+
+	fileID, err := GetAddressBookFileIDFor(0, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), fileID.Shard)
+	assert.Equal(t, uint64(0), fileID.Realm)
+	assert.Equal(t, uint64(102), fileID.File)
+	assert.Equal(t, FileIDForAddressBook(), fileID)
+
+	fileID, err = GetAddressBookFileIDFor(5, 3)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(3), fileID.Shard)
+	assert.Equal(t, uint64(5), fileID.Realm)
+	assert.Equal(t, uint64(102), fileID.File)
+
+	_, err = GetAddressBookFileIDFor(-1, 0)
+	assert.Error(t, err)
+	_, err = GetAddressBookFileIDFor(0, -1)
+	assert.Error(t, err)
+	_, err = GetAddressBookFileIDFor(-1, -1)
+	assert.Error(t, err)
+}
+
+func TestUnitGetFeeScheduleFileIDFor(t *testing.T) {
+	t.Parallel()
+
+	fileID, err := GetFeeScheduleFileIDFor(0, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), fileID.Shard)
+	assert.Equal(t, uint64(0), fileID.Realm)
+	assert.Equal(t, uint64(111), fileID.File)
+	assert.Equal(t, FileIDForFeeSchedule(), fileID)
+
+	fileID, err = GetFeeScheduleFileIDFor(5, 3)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(3), fileID.Shard)
+	assert.Equal(t, uint64(5), fileID.Realm)
+	assert.Equal(t, uint64(111), fileID.File)
+
+	_, err = GetFeeScheduleFileIDFor(-1, 0)
+	assert.Error(t, err)
+	_, err = GetFeeScheduleFileIDFor(0, -1)
+	assert.Error(t, err)
+	_, err = GetFeeScheduleFileIDFor(-1, -1)
+	assert.Error(t, err)
+}
+
+func TestUnitGetExchangeRatesFileIDFor(t *testing.T) {
+	t.Parallel()
+
+	fileID, err := GetExchangeRatesFileIDFor(0, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), fileID.Shard)
+	assert.Equal(t, uint64(0), fileID.Realm)
+	assert.Equal(t, uint64(112), fileID.File)
+	assert.Equal(t, FileIDForExchangeRate(), fileID)
+
+	fileID, err = GetExchangeRatesFileIDFor(5, 3)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(3), fileID.Shard)
+	assert.Equal(t, uint64(5), fileID.Realm)
+	assert.Equal(t, uint64(112), fileID.File)
+
+	_, err = GetAddressBookFileIDFor(-1, 0)
+	assert.Error(t, err)
+	_, err = GetFeeScheduleFileIDFor(0, -1)
+	assert.Error(t, err)
+	_, err = GetExchangeRatesFileIDFor(-1, -1)
+	assert.Error(t, err)
+}

--- a/sdk/file_id_unit_test.go
+++ b/sdk/file_id_unit_test.go
@@ -65,71 +65,44 @@ func TestUnitFileIDChecksumError(t *testing.T) {
 func TestUnitGetAddressBookFileIDFor(t *testing.T) {
 	t.Parallel()
 
-	fileID, err := GetAddressBookFileIDFor(0, 0)
-	assert.NoError(t, err)
+	fileID := GetAddressBookFileIDFor(0, 0)
 	assert.Equal(t, uint64(0), fileID.Shard)
 	assert.Equal(t, uint64(0), fileID.Realm)
 	assert.Equal(t, uint64(102), fileID.File)
 	assert.Equal(t, FileIDForAddressBook(), fileID)
 
-	fileID, err = GetAddressBookFileIDFor(5, 3)
-	assert.NoError(t, err)
+	fileID = GetAddressBookFileIDFor(5, 3)
 	assert.Equal(t, uint64(3), fileID.Shard)
 	assert.Equal(t, uint64(5), fileID.Realm)
 	assert.Equal(t, uint64(102), fileID.File)
-
-	_, err = GetAddressBookFileIDFor(-1, 0)
-	assert.Error(t, err)
-	_, err = GetAddressBookFileIDFor(0, -1)
-	assert.Error(t, err)
-	_, err = GetAddressBookFileIDFor(-1, -1)
-	assert.Error(t, err)
 }
 
 func TestUnitGetFeeScheduleFileIDFor(t *testing.T) {
 	t.Parallel()
 
-	fileID, err := GetFeeScheduleFileIDFor(0, 0)
-	assert.NoError(t, err)
+	fileID := GetFeeScheduleFileIDFor(0, 0)
 	assert.Equal(t, uint64(0), fileID.Shard)
 	assert.Equal(t, uint64(0), fileID.Realm)
 	assert.Equal(t, uint64(111), fileID.File)
 	assert.Equal(t, FileIDForFeeSchedule(), fileID)
 
-	fileID, err = GetFeeScheduleFileIDFor(5, 3)
-	assert.NoError(t, err)
+	fileID = GetFeeScheduleFileIDFor(5, 3)
 	assert.Equal(t, uint64(3), fileID.Shard)
 	assert.Equal(t, uint64(5), fileID.Realm)
 	assert.Equal(t, uint64(111), fileID.File)
-
-	_, err = GetFeeScheduleFileIDFor(-1, 0)
-	assert.Error(t, err)
-	_, err = GetFeeScheduleFileIDFor(0, -1)
-	assert.Error(t, err)
-	_, err = GetFeeScheduleFileIDFor(-1, -1)
-	assert.Error(t, err)
 }
 
 func TestUnitGetExchangeRatesFileIDFor(t *testing.T) {
 	t.Parallel()
 
-	fileID, err := GetExchangeRatesFileIDFor(0, 0)
-	assert.NoError(t, err)
+	fileID := GetExchangeRatesFileIDFor(0, 0)
 	assert.Equal(t, uint64(0), fileID.Shard)
 	assert.Equal(t, uint64(0), fileID.Realm)
 	assert.Equal(t, uint64(112), fileID.File)
 	assert.Equal(t, FileIDForExchangeRate(), fileID)
 
-	fileID, err = GetExchangeRatesFileIDFor(5, 3)
-	assert.NoError(t, err)
+	fileID = GetExchangeRatesFileIDFor(5, 3)
 	assert.Equal(t, uint64(3), fileID.Shard)
 	assert.Equal(t, uint64(5), fileID.Realm)
 	assert.Equal(t, uint64(112), fileID.File)
-
-	_, err = GetAddressBookFileIDFor(-1, 0)
-	assert.Error(t, err)
-	_, err = GetFeeScheduleFileIDFor(0, -1)
-	assert.Error(t, err)
-	_, err = GetExchangeRatesFileIDFor(-1, -1)
-	assert.Error(t, err)
 }

--- a/sdk/mirror_network.go
+++ b/sdk/mirror_network.go
@@ -4,6 +4,8 @@ package hiero
 
 import (
 	"math/rand"
+
+	"github.com/pkg/errors"
 )
 
 type _MirrorNetwork struct {
@@ -42,10 +44,14 @@ func (network *_MirrorNetwork) _SetTransportSecurity(transportSecurity bool) *_M
 	return network
 }
 
-func (network *_MirrorNetwork) _GetNextMirrorNode() *_MirrorNode {
-	node := network._ManagedNetwork.healthyNodes[rand.Intn(len(network.healthyNodes))] // nolint
-	if node, ok := node.(*_MirrorNode); ok {
-		return node
+func (network *_MirrorNetwork) _GetNextMirrorNode() (*_MirrorNode, error) {
+	if len(network.healthyNodes) == 0 {
+		return nil, errors.New("no healthy nodes")
 	}
-	return &_MirrorNode{}
+
+	node := network.healthyNodes[rand.Intn(len(network.healthyNodes))] // nolint
+	if node, ok := node.(*_MirrorNode); ok {
+		return node, nil
+	}
+	return &_MirrorNode{}, nil
 }

--- a/sdk/topic_message_query.go
+++ b/sdk/topic_message_query.go
@@ -182,7 +182,12 @@ func (query *TopicMessageQuery) Subscribe(client *Client, onNext func(TopicMessa
 
 	messages := make(map[string][]*mirror.ConsensusTopicResponse)
 
-	channel, err := client.mirrorNetwork._GetNextMirrorNode()._GetConsensusServiceClient()
+	mirrorNode, err := client.mirrorNetwork._GetNextMirrorNode()
+	if err != nil {
+		return handle, err
+	}
+
+	channel, err := mirrorNode._GetConsensusServiceClient()
 	if err != nil {
 		return handle, err
 	}


### PR DESCRIPTION
**Description**:

This PR aims to provide new APIs to allow a user to set which realm and shard from which to retrieve a static file, as well as fixing the `AddressBookQuery` used by `Client.forMirrorNetwork()`.

## New APIs

### `FileId FileId.getAddressBookFileIdFor(uint64 realm, uint64 shard)`

- `uint64 realm`: The realm from which to get the address book file ID.
- `uint64 shard`: The shard from which to get the address book file ID.

### `FileId FileId.getFeeScheduleFileIdFor(uint64 realm, uint64 shard)`

- `uint64 realm`: The realm from which to get the fee schedule file ID.
- `uint64 shard`: The shard from which to get the fee schedule file ID.

### `FileId FileId.getExchangeRatesFileIdFor(uint64 realm, uint64 shard)`

- `uint64 realm`: The realm from which to get the exchange rates file ID.
- `uint64 shard`: The shard from which to get the exchange rates file ID.

### `Client Client.forMirrorNetwork(List<string>, uint64 realm, uint64 shard)`
**Description**: `forMirrorNetwork` uses a list of mirror node URLs to query and get the address book for a network and uses that address book to initialize the `Client` network. Additions need to be made to this function signature to allow realm and shard values to be passed, so the correct address book can be queried.


Fixes #1359

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
