### PR TITLE
fix: Static utility transaction methods for chunked transactions

### DIFF
--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -1629,6 +1629,16 @@ func (tx *Transaction[T]) SetLogLevel(level LogLevel) T {
 // Static Utility functions //
 
 func TransactionExecute(tx TransactionInterface, client *Client) (TransactionResponse, error) {
+	fileAppendTx, ok := tx.(*FileAppendTransaction)
+	if ok {
+		return fileAppendTx.Execute(client)
+	}
+
+	messageSubmitTx, ok := tx.(*TopicMessageSubmitTransaction)
+	if ok {
+		return messageSubmitTx.Execute(client)
+	}
+
 	return tx.getBaseTransaction().Execute(client)
 }
 
@@ -1746,6 +1756,12 @@ func TransactionFreezeWith(tx TransactionInterface, client *Client) (Transaction
 	if ok {
 		return fileAppendTx.FreezeWith(client)
 	}
+
+	messageSubmitTx, ok := tx.(*TopicMessageSubmitTransaction)
+	if ok {
+		return messageSubmitTx.FreezeWith(client)
+	}
+
 	baseTx := tx.getBaseTransaction()
 	_, err := baseTx.FreezeWith(client)
 	if err != nil {


### PR DESCRIPTION
**Description**:

- Fixes `TransactionSign` and `TransactionExecute` to work with chunked transactions by calling the overridden implementations.


**Related issue(s)**:

Fixes #1472

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
