### PR TITLE
feat: add MirrorNodeAccountBalanceQuery

### DIFF
--- a/examples/mirror_node_account_balance/main.go
+++ b/examples/mirror_node_account_balance/main.go
@@ -33,8 +33,8 @@ func main() {
 	// Setting the client operator ID and key
 	client.SetOperator(operatorAccountID, operatorKey)
 
-	// MirrorNodeAccountBalanceQuery replaces the deprecated AccountBalanceQuery, which the
-	// consensus node stops serving in release 0.77. It reads from the mirror node REST API, so it
+	// MirrorNodeAccountBalanceQuery replaces AccountBalanceQuery, which the consensus node stops
+	// serving in release 0.77. It reads from the mirror node REST API, so it
 	// is free and needs no query payment.
 	balance, err := hiero.NewMirrorNodeAccountBalanceQuery().
 		SetAccountID(operatorAccountID).

--- a/examples/mirror_node_account_balance/main.go
+++ b/examples/mirror_node_account_balance/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	hiero "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
+)
+
+func main() {
+	var client *hiero.Client
+	var err error
+
+	// Retrieving network type from environment variable HEDERA_NETWORK
+	client, err = hiero.ClientForName(os.Getenv("HEDERA_NETWORK"))
+	if err != nil {
+		panic(fmt.Sprintf("%v : error creating client", err))
+	}
+
+	// Retrieving operator ID from environment variable OPERATOR_ID
+	operatorAccountID, err := hiero.AccountIDFromString(os.Getenv("OPERATOR_ID"))
+	if err != nil {
+		panic(fmt.Sprintf("%v : error converting string to AccountID", err))
+	}
+
+	// Retrieving operator key from environment variable OPERATOR_KEY
+	operatorKey, err := hiero.PrivateKeyFromString(os.Getenv("OPERATOR_KEY"))
+	if err != nil {
+		panic(fmt.Sprintf("%v : error converting string to PrivateKey", err))
+	}
+
+	// Setting the client operator ID and key
+	client.SetOperator(operatorAccountID, operatorKey)
+
+	// MirrorNodeAccountBalanceQuery replaces the deprecated AccountBalanceQuery, which the
+	// consensus node stops serving in release 0.77. It reads from the mirror node REST API, so it
+	// is free and needs no query payment.
+	balance, err := hiero.NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(operatorAccountID).
+		Execute(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error executing mirror node account balance query", err))
+	}
+
+	fmt.Printf("balance = %v\n", balance.Hbars.String())
+
+	// The account can also be addressed by anything the mirror node resolves: an EVM address, a
+	// public key alias, or a contract ID. A contract goes through SetAccountID as well -- there is
+	// no SetContractID, because the balances endpoint takes a contract through the same parameter.
+	//
+	//	contractAccountID := hiero.AccountID{
+	//		Shard: contractID.Shard, Realm: contractID.Realm, Account: contractID.Contract,
+	//	}
+
+	// The mirror node ingests consensus state asynchronously and trails the network by a few
+	// seconds, so a balance read immediately after a transfer may still show the old value. Poll
+	// until the expected value appears rather than trusting a single read.
+	transfer, err := hiero.NewTransferTransaction().
+		AddHbarTransfer(operatorAccountID, hiero.NewHbar(-1)).
+		AddHbarTransfer(hiero.AccountID{Account: 3}, hiero.NewHbar(1)).
+		Execute(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error executing transfer transaction", err))
+	}
+	if _, err = transfer.SetValidateStatus(true).GetReceipt(client); err != nil {
+		panic(fmt.Sprintf("%v : error getting transfer receipt", err))
+	}
+
+	spent := balance.Hbars.AsTinybar()
+	for attempt := 0; attempt < 10; attempt++ {
+		if attempt > 0 {
+			time.Sleep(2 * time.Second)
+		}
+
+		updated, err := hiero.NewMirrorNodeAccountBalanceQuery().
+			SetAccountID(operatorAccountID).
+			Execute(client)
+		if err != nil {
+			panic(fmt.Sprintf("%v : error executing mirror node account balance query", err))
+		}
+
+		if updated.Hbars.AsTinybar() < spent {
+			fmt.Printf("balance after transfer = %v\n", updated.Hbars.String())
+			return
+		}
+	}
+
+	fmt.Println("mirror node had not yet ingested the transfer")
+}

--- a/sdk/account_id.go
+++ b/sdk/account_id.go
@@ -340,17 +340,9 @@ const (
 	EvmAddress
 )
 
-// _MirrorNodePathID renders the AccountID in a form /accounts/{idOrAliasOrEvmAddress} accepts: an
-// EVM-address alias as bare hex, a public-key alias as base32 (RFC 4648, no padding) of the
-// serialized key -- what the mirror node itself reports -- and anything else as shard.realm.num.
-//
-// The numeric form wins whenever it is available, because it is canonical and because an alias ID
-// keeps its alias field after PopulateAccount fills in the account number. 0.0.0 is not a real
-// account, so a zero Account means only the alias can identify this ID.
-//
-// Note that the alias forms carry no shard.realm prefix; the mirror node resolves an alias without
-// one. A contract is addressed through the same numeric form, so no separate contract variant is
-// needed.
+// _MirrorNodePathID renders the AccountID as the mirror node accepts it: shard.realm.num when a
+// number is set, otherwise an EVM-address alias as bare hex or a public key alias as unpadded
+// base32. Alias forms carry no shard.realm prefix.
 func (id AccountID) _MirrorNodePathID() string {
 	if id.Account != 0 {
 		return fmt.Sprintf("%d.%d.%d", id.Shard, id.Realm, id.Account)

--- a/sdk/account_id.go
+++ b/sdk/account_id.go
@@ -1,6 +1,7 @@
 package hiero
 
 import (
+	"encoding/base32"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -339,21 +340,42 @@ const (
 	EvmAddress
 )
 
-func (id *AccountID) _MirrorNodeRequest(client *Client, populateType string) (map[string]interface{}, error) {
-	if client.mirrorNetwork == nil || len(client.GetMirrorNetwork()) == 0 {
-		return nil, errors.New("mirror node is not set")
+// _MirrorNodePathID renders the AccountID in a form /accounts/{idOrAliasOrEvmAddress} accepts: an
+// EVM-address alias as bare hex, a public-key alias as base32 (RFC 4648, no padding) of the
+// serialized key -- what the mirror node itself reports -- and anything else as shard.realm.num.
+//
+// The numeric form wins whenever it is available, because it is canonical and because an alias ID
+// keeps its alias field after PopulateAccount fills in the account number. 0.0.0 is not a real
+// account, so a zero Account means only the alias can identify this ID.
+//
+// Note that the alias forms carry no shard.realm prefix; the mirror node resolves an alias without
+// one. A contract is addressed through the same numeric form, so no separate contract variant is
+// needed.
+func (id AccountID) _MirrorNodePathID() string {
+	if id.Account != 0 {
+		return fmt.Sprintf("%d.%d.%d", id.Shard, id.Realm, id.Account)
 	}
 
-	mirrorUrl, err := client.GetMirrorRestApiBaseUrl()
+	switch {
+	case id.AliasEvmAddress != nil:
+		return hex.EncodeToString(*id.AliasEvmAddress)
+	case id.AliasKey != nil:
+		if aliasBytes, err := protobuf.Marshal(id.AliasKey._ToProtoKey()); err == nil {
+			return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(aliasBytes)
+		}
+		return id.String()
+	default:
+		return id.String()
+	}
+}
+
+func (id *AccountID) _MirrorNodeRequest(client *Client) (map[string]interface{}, error) {
+	mirrorUrl, err := mirrorNodeRestBaseURL(client)
 	if err != nil {
 		return nil, err
 	}
 
-	if populateType == "account" {
-		mirrorUrl = fmt.Sprintf("%s/accounts/%s", mirrorUrl, hex.EncodeToString(*id.AliasEvmAddress))
-	} else {
-		mirrorUrl = fmt.Sprintf("%s/accounts/%s", mirrorUrl, id.String())
-	}
+	mirrorUrl = fmt.Sprintf("%s/accounts/%s", mirrorUrl, id._MirrorNodePathID())
 
 	resp, err := http.Get(mirrorUrl) // #nosec
 	if err != nil {
@@ -373,7 +395,7 @@ func (id *AccountID) _MirrorNodeRequest(client *Client, populateType string) (ma
 // Should be used after generating `AccountId.FromEvmAddress()` because it sets the `Account` field to `0`
 // automatically since there is no connection between the `Account` and the `evmAddress`
 func (id *AccountID) PopulateAccount(client *Client) error {
-	result, err := id._MirrorNodeRequest(client, "account")
+	result, err := id._MirrorNodeRequest(client)
 	if err != nil {
 		return err
 	}
@@ -394,7 +416,7 @@ func (id *AccountID) PopulateAccount(client *Client) error {
 
 // PopulateEvmAddress gets the actual `AliasEvmAddress` field of the `AccountId` from the Mirror Node.
 func (id *AccountID) PopulateEvmAddress(client *Client) error {
-	result, err := id._MirrorNodeRequest(client, "evmAddress")
+	result, err := id._MirrorNodeRequest(client)
 	if err != nil {
 		return err
 	}

--- a/sdk/account_id_unit_test.go
+++ b/sdk/account_id_unit_test.go
@@ -5,6 +5,7 @@ package hiero
 // SPDX-License-Identifier: Apache-2.0
 
 import (
+	"encoding/base32"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	protobuf "google.golang.org/protobuf/proto"
 )
 
 func TestUnitAccountIDChecksumFromString(t *testing.T) {
@@ -397,4 +399,36 @@ func TestUnitAccountIDPopulateWithDifferentPorts(t *testing.T) {
 			})
 		})
 	}
+}
+
+// Covers the three shapes /accounts/{idOrAliasOrEvmAddress} accepts.
+func TestUnitAccountIDMirrorNodePathID(t *testing.T) {
+	t.Parallel()
+
+	// Plain account number.
+	assert.Equal(t, "0.0.1234", AccountID{Account: 1234}._MirrorNodePathID())
+
+	// EVM-address alias: bare hex, no shard.realm prefix.
+	evm := []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01, 0x23, 0x45, 0x67}
+	assert.Equal(t, "00112233445566778899aabbccddeeff01234567",
+		AccountID{AliasEvmAddress: &evm}._MirrorNodePathID())
+
+	// Public-key alias: base32 (no padding) of the serialized key, no shard.realm prefix.
+	key, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+	aliasID := *key.PublicKey().ToAccountID(0, 0)
+
+	path := aliasID._MirrorNodePathID()
+	assert.NotContains(t, path, "0.0.", "public-key alias must not carry a shard.realm prefix")
+
+	aliasBytes, err := protobuf.Marshal(aliasID.AliasKey._ToProtoKey())
+	require.NoError(t, err)
+	expected := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(aliasBytes)
+	assert.Equal(t, expected, path)
+
+	// The encoding must decode back to the original alias bytes.
+	decoded, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(path)
+	require.NoError(t, err)
+	assert.Equal(t, aliasBytes, decoded)
 }

--- a/sdk/account_id_unit_test.go
+++ b/sdk/account_id_unit_test.go
@@ -432,3 +432,10 @@ func TestUnitAccountIDMirrorNodePathID(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, aliasBytes, decoded)
 }
+
+func TestUnitAccountIDMirrorNodePathIDWithoutNumOrAlias(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "0.0.0", AccountID{}._MirrorNodePathID())
+	assert.Equal(t, "1.2.0", AccountID{Shard: 1, Realm: 2}._MirrorNodePathID())
+}

--- a/sdk/errors.go
+++ b/sdk/errors.go
@@ -116,7 +116,8 @@ func (e ErrHederaNetwork) Error() string {
 }
 
 // ErrHederaPreCheckStatus is returned by Transaction.Execute and QueryBuilder.Execute if an exceptional status is
-// returned during _Network side validation of the sent transaction.
+// returned during _Network side validation of the sent transaction. MirrorNodeAccountBalanceQuery
+// also returns it, mapping an unknown account onto StatusInvalidAccountID.
 type ErrHederaPreCheckStatus struct {
 	TxID   TransactionID
 	Status Status

--- a/sdk/errors.go
+++ b/sdk/errors.go
@@ -21,6 +21,7 @@ var errNoClientOrTransactionID = errors.New("`client` must have an `_Operator` o
 var errNoClientOrTransactionIDOrNodeId = errors.New("`client` must be provided or both `nodeId` and `transactionId` must be set") // nolint
 var errClientOperatorSigning = errors.New("`client` must have an `_Operator` to sign with the _Operator")
 var errNoClientProvided = errors.New("`client` must be provided and have an _Operator")
+var errMirrorNodeAccountBalanceQueryNoAccountID = errors.New("`accountID` must be set on MirrorNodeAccountBalanceQuery")
 var errQueryPaymentRequiresOperator = errors.New("`client` must have an _Operator to pay for a query")
 var errTransactionIsNotFrozen = errors.New("transaction is not frozen")
 var errInnerTransactionShouldBeFrozen = errors.New("inner transaction should be frozen")

--- a/sdk/fee_estimate_query.go
+++ b/sdk/fee_estimate_query.go
@@ -5,8 +5,6 @@ package hiero
 import (
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"strings"
 
 	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
@@ -169,13 +167,9 @@ func (q *FeeEstimateQuery) estimateSingleTransaction(client *Client, tx Transact
 
 // callGetFeeEstimate calls the fee estimate REST API endpoint
 func (q *FeeEstimateQuery) callGetFeeEstimate(client *Client, protoTx *services.Transaction) (FeeEstimateResponse, error) {
-	if client.mirrorNetwork == nil || len(client.GetMirrorNetwork()) == 0 {
-		return FeeEstimateResponse{}, errors.New("mirror node is not set")
-	}
-
-	mirrorUrl, err := client.GetMirrorRestApiBaseUrl()
+	mirrorUrl, err := mirrorNodeRestBaseURL(client)
 	if err != nil {
-		return FeeEstimateResponse{}, errors.Wrap(err, "failed to get mirror REST API base URL")
+		return FeeEstimateResponse{}, err
 	}
 
 	isLocalHost := strings.Contains(mirrorUrl, "localhost") || strings.Contains(mirrorUrl, "127.0.0.1")
@@ -198,23 +192,10 @@ func (q *FeeEstimateQuery) callGetFeeEstimate(client *Client, protoTx *services.
 	if err != nil {
 		return FeeEstimateResponse{}, errors.Wrapf(err, "failed to call fee estimate API after %d attempts", q.maxAttempts)
 	}
-	if resp == nil {
-		return FeeEstimateResponse{}, errors.Wrap(errors.New("received nil response"), "failed to call fee estimate API")
-	}
-	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if readErr == nil {
-			return FeeEstimateResponse{}, errors.Wrap(fmt.Errorf("received non-200 response: %d, details: %s", resp.StatusCode, body), "failed to call fee estimate API")
-		}
-		return FeeEstimateResponse{}, errors.Wrap(fmt.Errorf("received non-200 response: %d", resp.StatusCode), "failed to call fee estimate API")
-	}
 
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
+	body, err := mirrorNodeReadBody(resp)
 	if err != nil {
-		return FeeEstimateResponse{}, errors.Wrap(err, "failed to read response body")
+		return FeeEstimateResponse{}, errors.Wrap(err, "failed to call fee estimate API")
 	}
 
 	var response FeeEstimateResponse

--- a/sdk/mirror_node.go
+++ b/sdk/mirror_node.go
@@ -42,16 +42,16 @@ func (node *_MirrorNode) getScheme() (string, error) {
 
 	// Standard HTTPS ports
 	if port == 443 {
-		return "https", nil
+		return mirrorNodeSchemeHTTPS, nil
 	}
 
 	// Standard HTTP ports
 	if port == 80 {
-		return "http", nil
+		return mirrorNodeSchemeHTTP, nil
 	}
 
 	// For other ports, assume HTTPS for security
-	return "https", nil
+	return mirrorNodeSchemeHTTPS, nil
 }
 
 func (node *_MirrorNode) getBaseRestUrl() (string, error) {

--- a/sdk/mirror_node_account_balance.go
+++ b/sdk/mirror_node_account_balance.go
@@ -1,0 +1,9 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+// MirrorNodeAccountBalance is the hbar balance returned by MirrorNodeAccountBalanceQuery.
+// Token balances are not included; the balances endpoint does not return them.
+type MirrorNodeAccountBalance struct {
+	Hbars Hbar
+}

--- a/sdk/mirror_node_account_balance_query.go
+++ b/sdk/mirror_node_account_balance_query.go
@@ -4,13 +4,16 @@ package hiero
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 )
 
 // MirrorNodeAccountBalanceQuery retrieves an account's or contract's hbar balance from the mirror
-// node REST API, replacing AccountBalanceQuery. It is free and requires no operator. The mirror node
-// trails the network by a few seconds, so results are not read-after-write consistent.
+// node REST API, replacing AccountBalanceQuery. It is free and requires no operator.
+//
+// The mirror node trails the network by a few seconds, so results are not read-after-write
+// consistent: a freshly created account fails with StatusInvalidAccountID until it is ingested.
 type MirrorNodeAccountBalanceQuery struct {
 	accountID   *AccountID
 	maxAttempts uint64
@@ -48,7 +51,7 @@ func (q *MirrorNodeAccountBalanceQuery) GetMaxAttempts() uint64 {
 	return q.maxAttempts
 }
 
-// Execute executes the Query with the provided client
+// Execute executes the query with the provided client
 func (q *MirrorNodeAccountBalanceQuery) Execute(client *Client) (MirrorNodeAccountBalance, error) {
 	if client == nil {
 		return MirrorNodeAccountBalance{}, errNoClientProvided
@@ -96,7 +99,6 @@ func (q *MirrorNodeAccountBalanceQuery) resolveAttempts(client *Client) uint64 {
 	return maxAttempts
 }
 
-// buildURL escapes the filter: an alias is opaque bytes and must not alter the query string.
 func (q *MirrorNodeAccountBalanceQuery) buildURL(mirrorBaseURL string) string {
 	params := url.Values{}
 	params.Set("account.id", q.accountID._MirrorNodePathID())
@@ -118,7 +120,6 @@ func (q *MirrorNodeAccountBalanceQuery) validateNetworkOnIDs(client *Client) err
 	return nil
 }
 
-// fetchAccountBalances GETs the balances endpoint through the shared retry core.
 func fetchAccountBalances(client *Client, endpoint string, attempts uint64) ([]byte, error) {
 	resp, err := mirrorNodeGetWithRetry(client, endpoint, attempts, mirrorNodeDefaultTimeout)
 	if err != nil {
@@ -128,16 +129,21 @@ func fetchAccountBalances(client *Client, endpoint string, attempts uint64) ([]b
 	return mirrorNodeReadBody(resp)
 }
 
-// parseAccountBalances reads an empty list as a zero balance: the endpoint returns one for an
-// unknown account rather than a 404, so zero is not proof the account exists.
+// parseAccountBalances maps an empty balances list onto StatusInvalidAccountID, the status
+// AccountBalanceQuery returned for an unknown account. The endpoint reports one as 200 with no rows.
 func parseAccountBalances(body []byte) (MirrorNodeAccountBalance, error) {
 	var raw accountBalancesResponseJSON
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return MirrorNodeAccountBalance{}, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
+	if raw.Balances == nil {
+		return MirrorNodeAccountBalance{}, errors.New("mirror node response has no balances array")
+	}
+
+	// An existing account with no hbar returns "balance": 0, so an empty list only means unknown.
 	if len(raw.Balances) == 0 {
-		return MirrorNodeAccountBalance{Hbars: HbarFromTinybar(0)}, nil
+		return MirrorNodeAccountBalance{}, ErrHederaPreCheckStatus{Status: StatusInvalidAccountID}
 	}
 
 	return MirrorNodeAccountBalance{Hbars: HbarFromTinybar(raw.Balances[0].Balance)}, nil
@@ -149,6 +155,5 @@ type accountBalancesResponseJSON struct {
 }
 
 type accountBalanceJSON struct {
-	Account string `json:"account"`
-	Balance int64  `json:"balance"`
+	Balance int64 `json:"balance"`
 }

--- a/sdk/mirror_node_account_balance_query.go
+++ b/sdk/mirror_node_account_balance_query.go
@@ -1,0 +1,156 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+// MirrorNodeAccountBalanceQuery retrieves an account's or contract's hbar balance from the mirror
+// node REST API, replacing AccountBalanceQuery. It is free and requires no operator. The mirror node
+// trails the network by a few seconds, so results are not read-after-write consistent.
+type MirrorNodeAccountBalanceQuery struct {
+	accountID   *AccountID
+	maxAttempts uint64
+}
+
+// NewMirrorNodeAccountBalanceQuery creates a new MirrorNodeAccountBalanceQuery
+func NewMirrorNodeAccountBalanceQuery() *MirrorNodeAccountBalanceQuery {
+	return &MirrorNodeAccountBalanceQuery{}
+}
+
+// SetAccountID sets the account to query. Accepts shard.realm.num, an EVM address, a public key
+// alias, or a contract addressed as AccountID{Shard, Realm, Account: contractID.Contract}.
+func (q *MirrorNodeAccountBalanceQuery) SetAccountID(accountID AccountID) *MirrorNodeAccountBalanceQuery {
+	q.accountID = &accountID
+	return q
+}
+
+// GetAccountID returns the account to query, or the zero AccountID if not set.
+func (q *MirrorNodeAccountBalanceQuery) GetAccountID() AccountID {
+	if q.accountID == nil {
+		return AccountID{}
+	}
+	return *q.accountID
+}
+
+// SetMaxAttempts sets the total number of attempts (initial try + retries).
+// Zero (the default) defers to the client.
+func (q *MirrorNodeAccountBalanceQuery) SetMaxAttempts(maxAttempts uint64) *MirrorNodeAccountBalanceQuery {
+	q.maxAttempts = maxAttempts
+	return q
+}
+
+// GetMaxAttempts returns the configured retry budget, or 0 when it is left to the client.
+func (q *MirrorNodeAccountBalanceQuery) GetMaxAttempts() uint64 {
+	return q.maxAttempts
+}
+
+// Execute executes the Query with the provided client
+func (q *MirrorNodeAccountBalanceQuery) Execute(client *Client) (MirrorNodeAccountBalance, error) {
+	if client == nil {
+		return MirrorNodeAccountBalance{}, errNoClientProvided
+	}
+
+	if q.accountID == nil {
+		return MirrorNodeAccountBalance{}, errMirrorNodeAccountBalanceQueryNoAccountID
+	}
+
+	if err := q.validateNetworkOnIDs(client); err != nil {
+		return MirrorNodeAccountBalance{}, err
+	}
+
+	endpoint, err := q.resolveEndpoint(client)
+	if err != nil {
+		return MirrorNodeAccountBalance{}, err
+	}
+
+	body, err := fetchAccountBalances(client, endpoint, q.resolveAttempts(client))
+	if err != nil {
+		return MirrorNodeAccountBalance{}, err
+	}
+
+	return parseAccountBalances(body)
+}
+
+func (q *MirrorNodeAccountBalanceQuery) resolveEndpoint(client *Client) (string, error) {
+	mirrorUrl, err := mirrorNodeRestBaseURL(client)
+	if err != nil {
+		return "", err
+	}
+
+	return q.buildURL(mirrorUrl), nil
+}
+
+// resolveAttempts picks the retry budget: query, then client, then the SDK default. Not a single
+// attempt: Client.GetMaxAttempts reports -1 when unset and 5xx responses must still be retried.
+func (q *MirrorNodeAccountBalanceQuery) resolveAttempts(client *Client) uint64 {
+	if q.maxAttempts > 0 {
+		return q.maxAttempts
+	}
+	if clientMax := client.GetMaxAttempts(); clientMax > 0 {
+		return uint64(clientMax)
+	}
+	return maxAttempts
+}
+
+// buildURL escapes the filter: an alias is opaque bytes and must not alter the query string.
+func (q *MirrorNodeAccountBalanceQuery) buildURL(mirrorBaseURL string) string {
+	params := url.Values{}
+	params.Set("account.id", q.accountID._MirrorNodePathID())
+
+	return fmt.Sprintf("%s/balances?%s", mirrorBaseURL, params.Encode())
+}
+
+func (q *MirrorNodeAccountBalanceQuery) validateNetworkOnIDs(client *Client) error {
+	if client == nil || !client.autoValidateChecksums {
+		return nil
+	}
+
+	if q.accountID != nil {
+		if err := q.accountID.ValidateChecksum(client); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// fetchAccountBalances GETs the balances endpoint; the shared core retries 5xx/429 and transport
+// failures, and returns a 4xx as-is.
+func fetchAccountBalances(client *Client, endpoint string, attempts uint64) ([]byte, error) {
+	resp, err := mirrorNodeGetWithRetry(client, endpoint, attempts, mirrorNodeDefaultTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+
+	return mirrorNodeReadBody(resp)
+}
+
+// parseAccountBalances reads an empty list as a zero balance: the endpoint returns one for an
+// unknown account rather than a 404, so zero is not proof the account exists.
+func parseAccountBalances(body []byte) (MirrorNodeAccountBalance, error) {
+	var raw accountBalancesResponseJSON
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return MirrorNodeAccountBalance{}, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	if len(raw.Balances) == 0 {
+		return MirrorNodeAccountBalance{Hbars: HbarFromTinybar(0)}, nil
+	}
+
+	return MirrorNodeAccountBalance{Hbars: HbarFromTinybar(raw.Balances[0].Balance)}, nil
+}
+
+// An exact account.id filter matches one account, so there is never a next page to follow.
+type accountBalancesResponseJSON struct {
+	Balances []accountBalanceJSON `json:"balances"`
+}
+
+type accountBalanceJSON struct {
+	Account string `json:"account"`
+	// Tinybars; int64 holds the whole hbar supply exactly.
+	Balance int64 `json:"balance"`
+}

--- a/sdk/mirror_node_account_balance_query.go
+++ b/sdk/mirror_node_account_balance_query.go
@@ -84,8 +84,8 @@ func (q *MirrorNodeAccountBalanceQuery) resolveEndpoint(client *Client) (string,
 	return q.buildURL(mirrorUrl), nil
 }
 
-// resolveAttempts picks the retry budget: query, then client, then the SDK default. Not a single
-// attempt: Client.GetMaxAttempts reports -1 when unset and 5xx responses must still be retried.
+// resolveAttempts picks the retry budget: query setting first,
+// client default second, the SDK default as the final fallback.
 func (q *MirrorNodeAccountBalanceQuery) resolveAttempts(client *Client) uint64 {
 	if q.maxAttempts > 0 {
 		return q.maxAttempts
@@ -118,8 +118,7 @@ func (q *MirrorNodeAccountBalanceQuery) validateNetworkOnIDs(client *Client) err
 	return nil
 }
 
-// fetchAccountBalances GETs the balances endpoint; the shared core retries 5xx/429 and transport
-// failures, and returns a 4xx as-is.
+// fetchAccountBalances GETs the balances endpoint through the shared retry core.
 func fetchAccountBalances(client *Client, endpoint string, attempts uint64) ([]byte, error) {
 	resp, err := mirrorNodeGetWithRetry(client, endpoint, attempts, mirrorNodeDefaultTimeout)
 	if err != nil {
@@ -151,6 +150,5 @@ type accountBalancesResponseJSON struct {
 
 type accountBalanceJSON struct {
 	Account string `json:"account"`
-	// Tinybars; int64 holds the whole hbar supply exactly.
-	Balance int64 `json:"balance"`
+	Balance int64  `json:"balance"`
 }

--- a/sdk/mirror_node_account_balance_query.go
+++ b/sdk/mirror_node_account_balance_query.go
@@ -88,7 +88,7 @@ func (q *MirrorNodeAccountBalanceQuery) resolveEndpoint(client *Client) (string,
 }
 
 // resolveAttempts picks the retry budget: query setting first,
-// client default second, the SDK default as the final fallback.
+// client default second, the mirror node default as the final fallback.
 func (q *MirrorNodeAccountBalanceQuery) resolveAttempts(client *Client) uint64 {
 	if q.maxAttempts > 0 {
 		return q.maxAttempts
@@ -96,7 +96,7 @@ func (q *MirrorNodeAccountBalanceQuery) resolveAttempts(client *Client) uint64 {
 	if clientMax := client.GetMaxAttempts(); clientMax > 0 {
 		return uint64(clientMax)
 	}
-	return maxAttempts
+	return mirrorNodeDefaultMaxAttempts
 }
 
 func (q *MirrorNodeAccountBalanceQuery) buildURL(mirrorBaseURL string) string {
@@ -107,17 +107,17 @@ func (q *MirrorNodeAccountBalanceQuery) buildURL(mirrorBaseURL string) string {
 }
 
 func (q *MirrorNodeAccountBalanceQuery) validateNetworkOnIDs(client *Client) error {
-	if client == nil || !client.autoValidateChecksums {
+	if client == nil || !client.autoValidateChecksums || q.accountID == nil {
 		return nil
 	}
 
-	if q.accountID != nil {
-		if err := q.accountID.ValidateChecksum(client); err != nil {
-			return err
-		}
+	// Only an ID with no account number is sent as an alias (see _MirrorNodePathID), and an alias
+	// carries no checksum to validate. Anything sent by number is validated as usual.
+	if q.accountID.Account == 0 && (q.accountID.AliasKey != nil || q.accountID.AliasEvmAddress != nil) {
+		return nil
 	}
 
-	return nil
+	return q.accountID.ValidateChecksum(client)
 }
 
 func fetchAccountBalances(client *Client, endpoint string, attempts uint64) ([]byte, error) {

--- a/sdk/mirror_node_account_balance_query_e2e_test.go
+++ b/sdk/mirror_node_account_balance_query_e2e_test.go
@@ -5,6 +5,7 @@ package hiero
 // SPDX-License-Identifier: Apache-2.0
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -30,6 +31,10 @@ func mirrorHbarBalanceEventually(env *IntegrationTestEnv, query *MirrorNodeAccou
 		if err == nil && ready(balance) {
 			return balance, nil
 		}
+	}
+
+	if err == nil {
+		err = fmt.Errorf("mirror node did not reach the expected state within %d attempts", mirrorHbarBalanceRetryAttempts)
 	}
 
 	return balance, err
@@ -160,6 +165,16 @@ func TestIntegrationMirrorNodeAccountBalanceQueryCanGetContractBalance(t *testin
 	require.NoError(t, err)
 	contractID := *receipt.ContractID
 
+	defer func() {
+		_, err := NewContractDeleteTransaction().
+			SetContractID(contractID).
+			SetTransferAccountID(env.Client.GetOperatorAccountID()).
+			Execute(env.Client)
+		require.NoError(t, err)
+		_, err = NewFileDeleteTransaction().SetFileID(fileID).Execute(env.Client)
+		require.NoError(t, err)
+	}()
+
 	contractAccountID := AccountID{Shard: contractID.Shard, Realm: contractID.Realm, Account: contractID.Contract}
 
 	tx, err := NewTransferTransaction().
@@ -178,26 +193,18 @@ func TestIntegrationMirrorNodeAccountBalanceQueryCanGetContractBalance(t *testin
 	require.NoError(t, err)
 	assert.Equal(t, NewHbar(1).AsTinybar(), balance.Hbars.AsTinybar())
 
-	_, err = NewContractDeleteTransaction().
-		SetContractID(contractID).
-		SetTransferAccountID(env.Client.GetOperatorAccountID()).
-		Execute(env.Client)
-	require.NoError(t, err)
-	_, err = NewFileDeleteTransaction().
-		SetFileID(fileID).
-		Execute(env.Client)
-	require.NoError(t, err)
 }
 
-func TestIntegrationMirrorNodeAccountBalanceQueryNonExistentAccountIsZero(t *testing.T) {
+func TestIntegrationMirrorNodeAccountBalanceQueryNonExistentAccountErrors(t *testing.T) {
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 	defer CloseIntegrationTestEnv(env, nil)
 
-	balance, err := NewMirrorNodeAccountBalanceQuery().
+	_, err := NewMirrorNodeAccountBalanceQuery().
 		SetAccountID(AccountID{Account: 999999999}).
 		Execute(env.Client)
 
-	require.NoError(t, err, "an unknown account is an empty balances array, not an error")
-	assert.Zero(t, balance.Hbars.AsTinybar())
+	var status ErrHederaPreCheckStatus
+	require.ErrorAs(t, err, &status)
+	assert.Equal(t, StatusInvalidAccountID, status.Status)
 }

--- a/sdk/mirror_node_account_balance_query_e2e_test.go
+++ b/sdk/mirror_node_account_balance_query_e2e_test.go
@@ -1,0 +1,216 @@
+//go:build all || e2e
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	mirrorHbarBalanceRetryAttempts = 10
+	mirrorHbarBalanceRetryDelay    = 2 * time.Second
+)
+
+// mirrorHbarBalanceEventually polls until ready accepts the result, absorbing mirror node ingestion
+// lag. On timeout it returns the last balance and error so the caller's assertion reports it.
+func mirrorHbarBalanceEventually(env *IntegrationTestEnv, query *MirrorNodeAccountBalanceQuery, ready func(MirrorNodeAccountBalance) bool) (MirrorNodeAccountBalance, error) {
+	var balance MirrorNodeAccountBalance
+	var err error
+
+	for attempt := 0; attempt < mirrorHbarBalanceRetryAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(mirrorHbarBalanceRetryDelay)
+		}
+		balance, err = query.Execute(env.Client)
+		if err == nil && ready(balance) {
+			return balance, nil
+		}
+	}
+
+	return balance, err
+}
+
+func nonZeroHbars(balance MirrorNodeAccountBalance) bool {
+	return balance.Hbars.AsTinybar() > 0
+}
+
+// Acceptance 1: a valid account ID returns the hbar balance the mirror node holds.
+func TestIntegrationMirrorNodeAccountBalanceQueryCanExecute(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	balance, err := mirrorHbarBalanceEventually(
+		&env,
+		NewMirrorNodeAccountBalanceQuery().SetAccountID(env.OperatorID),
+		nonZeroHbars,
+	)
+	require.NoError(t, err)
+	assert.Positive(t, balance.Hbars.AsTinybar(), "the operator account must hold hbars")
+}
+
+// The query is free and must work without an operator, unlike the consensus-node queries.
+func TestIntegrationMirrorNodeAccountBalanceQueryWithoutOperator(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	operatorID := env.OperatorID
+	env.Client.operator = nil
+
+	balance, err := mirrorHbarBalanceEventually(
+		&env,
+		NewMirrorNodeAccountBalanceQuery().SetAccountID(operatorID),
+		nonZeroHbars,
+	)
+	require.NoError(t, err)
+	assert.Positive(t, balance.Hbars.AsTinybar())
+}
+
+// Acceptance 6: an unset account ID fails before any request is made.
+func TestIntegrationMirrorNodeAccountBalanceQueryNoIDError(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	_, err := NewMirrorNodeAccountBalanceQuery().Execute(env.Client)
+	require.ErrorIs(t, err, errMirrorNodeAccountBalanceQueryNoAccountID)
+}
+
+// Acceptance 2: an account addressed by its EVM address alias resolves and returns its balance.
+func TestIntegrationMirrorNodeAccountBalanceQueryCanGetBalanceByEvmAddress(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	// Auto-create the account by funding a fresh ECDSA key's EVM address.
+	privateKey, err := PrivateKeyGenerateEcdsa()
+	require.NoError(t, err)
+	evmAddressAccount, err := AccountIDFromEvmPublicAddress(privateKey.PublicKey().ToEvmAddress())
+	require.NoError(t, err)
+
+	tx, err := NewTransferTransaction().
+		AddHbarTransfer(evmAddressAccount, NewHbar(1)).
+		AddHbarTransfer(env.OperatorID, NewHbar(-1)).
+		Execute(env.Client)
+	require.NoError(t, err)
+	_, err = tx.SetIncludeChildren(true).SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	// Query by the alias itself; no account number is known here.
+	balance, err := mirrorHbarBalanceEventually(
+		&env,
+		NewMirrorNodeAccountBalanceQuery().SetAccountID(evmAddressAccount),
+		nonZeroHbars,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, NewHbar(1).AsTinybar(), balance.Hbars.AsTinybar())
+}
+
+// Acceptance 3: an account addressed by an ED25519 public-key alias resolves and returns its balance.
+func TestIntegrationMirrorNodeAccountBalanceQueryCanGetBalanceByPublicKeyAlias(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	key, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+	aliasAccountID := *key.PublicKey().ToAccountID(0, 0)
+
+	tx, err := NewTransferTransaction().
+		AddHbarTransfer(aliasAccountID, NewHbar(1)).
+		AddHbarTransfer(env.OperatorID, NewHbar(-1)).
+		Execute(env.Client)
+	require.NoError(t, err)
+	_, err = tx.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	balance, err := mirrorHbarBalanceEventually(
+		&env,
+		NewMirrorNodeAccountBalanceQuery().SetAccountID(aliasAccountID),
+		nonZeroHbars,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, NewHbar(1).AsTinybar(), balance.Hbars.AsTinybar())
+}
+
+// Acceptance 4: a contract's balance is read through the same account.id parameter.
+func TestIntegrationMirrorNodeAccountBalanceQueryCanGetContractBalance(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	resp, err := NewFileCreateTransaction().
+		SetKeys(env.Client.GetOperatorPublicKey()).
+		SetNodeAccountIDs(env.NodeAccountIDs).
+		SetContents([]byte(SIMPLE_SMART_CONTRACT_BYTECODE)).
+		Execute(env.Client)
+	require.NoError(t, err)
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+	fileID := *receipt.FileID
+
+	resp, err = NewContractCreateTransaction().
+		SetAdminKey(env.Client.GetOperatorPublicKey()).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		SetGas(contractDeployGas).
+		SetConstructorParameters(NewContractFunctionParameters().AddString("hello from hiero")).
+		SetBytecodeFileID(fileID).
+		SetContractMemo("hiero-sdk-go::MirrorNodeAccountBalanceQuery").
+		Execute(env.Client)
+	require.NoError(t, err)
+	receipt, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+	contractID := *receipt.ContractID
+
+	// No SetContractID: a contract goes through account.id as the equivalent AccountID.
+	contractAccountID := AccountID{Shard: contractID.Shard, Realm: contractID.Realm, Account: contractID.Contract}
+
+	// Fund by transfer: the constructor is not payable, so an initial balance reverts.
+	tx, err := NewTransferTransaction().
+		AddHbarTransfer(contractAccountID, NewHbar(1)).
+		AddHbarTransfer(env.OperatorID, NewHbar(-1)).
+		Execute(env.Client)
+	require.NoError(t, err)
+	_, err = tx.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	balance, err := mirrorHbarBalanceEventually(
+		&env,
+		NewMirrorNodeAccountBalanceQuery().SetAccountID(contractAccountID),
+		nonZeroHbars,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, NewHbar(1).AsTinybar(), balance.Hbars.AsTinybar())
+
+	_, err = NewContractDeleteTransaction().
+		SetContractID(contractID).
+		SetTransferAccountID(env.Client.GetOperatorAccountID()).
+		Execute(env.Client)
+	require.NoError(t, err)
+	_, err = NewFileDeleteTransaction().
+		SetFileID(fileID).
+		Execute(env.Client)
+	require.NoError(t, err)
+}
+
+// Acceptance 5: an unknown account yields a zero balance, not an error -- the endpoint returns an
+// empty list rather than a 404, unlike the consensus-node query's INVALID_ACCOUNT_ID.
+func TestIntegrationMirrorNodeAccountBalanceQueryNonExistentAccountIsZero(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	balance, err := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{Account: 999999999}).
+		Execute(env.Client)
+
+	require.NoError(t, err, "an unknown account is an empty balances array, not an error")
+	assert.Zero(t, balance.Hbars.AsTinybar())
+}

--- a/sdk/mirror_node_account_balance_query_e2e_test.go
+++ b/sdk/mirror_node_account_balance_query_e2e_test.go
@@ -17,8 +17,7 @@ const (
 	mirrorHbarBalanceRetryDelay    = 2 * time.Second
 )
 
-// mirrorHbarBalanceEventually polls until ready accepts the result, absorbing mirror node ingestion
-// lag. On timeout it returns the last balance and error so the caller's assertion reports it.
+// mirrorHbarBalanceEventually polls until ready accepts the result, absorbing mirror node lag.
 func mirrorHbarBalanceEventually(env *IntegrationTestEnv, query *MirrorNodeAccountBalanceQuery, ready func(MirrorNodeAccountBalance) bool) (MirrorNodeAccountBalance, error) {
 	var balance MirrorNodeAccountBalance
 	var err error
@@ -40,7 +39,6 @@ func nonZeroHbars(balance MirrorNodeAccountBalance) bool {
 	return balance.Hbars.AsTinybar() > 0
 }
 
-// Acceptance 1: a valid account ID returns the hbar balance the mirror node holds.
 func TestIntegrationMirrorNodeAccountBalanceQueryCanExecute(t *testing.T) {
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
@@ -55,7 +53,6 @@ func TestIntegrationMirrorNodeAccountBalanceQueryCanExecute(t *testing.T) {
 	assert.Positive(t, balance.Hbars.AsTinybar(), "the operator account must hold hbars")
 }
 
-// The query is free and must work without an operator, unlike the consensus-node queries.
 func TestIntegrationMirrorNodeAccountBalanceQueryWithoutOperator(t *testing.T) {
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
@@ -73,7 +70,6 @@ func TestIntegrationMirrorNodeAccountBalanceQueryWithoutOperator(t *testing.T) {
 	assert.Positive(t, balance.Hbars.AsTinybar())
 }
 
-// Acceptance 6: an unset account ID fails before any request is made.
 func TestIntegrationMirrorNodeAccountBalanceQueryNoIDError(t *testing.T) {
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
@@ -83,7 +79,6 @@ func TestIntegrationMirrorNodeAccountBalanceQueryNoIDError(t *testing.T) {
 	require.ErrorIs(t, err, errMirrorNodeAccountBalanceQueryNoAccountID)
 }
 
-// Acceptance 2: an account addressed by its EVM address alias resolves and returns its balance.
 func TestIntegrationMirrorNodeAccountBalanceQueryCanGetBalanceByEvmAddress(t *testing.T) {
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
@@ -113,7 +108,6 @@ func TestIntegrationMirrorNodeAccountBalanceQueryCanGetBalanceByEvmAddress(t *te
 	assert.Equal(t, NewHbar(1).AsTinybar(), balance.Hbars.AsTinybar())
 }
 
-// Acceptance 3: an account addressed by an ED25519 public-key alias resolves and returns its balance.
 func TestIntegrationMirrorNodeAccountBalanceQueryCanGetBalanceByPublicKeyAlias(t *testing.T) {
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
@@ -140,7 +134,6 @@ func TestIntegrationMirrorNodeAccountBalanceQueryCanGetBalanceByPublicKeyAlias(t
 	assert.Equal(t, NewHbar(1).AsTinybar(), balance.Hbars.AsTinybar())
 }
 
-// Acceptance 4: a contract's balance is read through the same account.id parameter.
 func TestIntegrationMirrorNodeAccountBalanceQueryCanGetContractBalance(t *testing.T) {
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
@@ -159,20 +152,16 @@ func TestIntegrationMirrorNodeAccountBalanceQueryCanGetContractBalance(t *testin
 	resp, err = NewContractCreateTransaction().
 		SetAdminKey(env.Client.GetOperatorPublicKey()).
 		SetNodeAccountIDs([]AccountID{resp.NodeID}).
-		SetGas(contractDeployGas).
-		SetConstructorParameters(NewContractFunctionParameters().AddString("hello from hiero")).
+		SetGas(400_000).
 		SetBytecodeFileID(fileID).
-		SetContractMemo("hiero-sdk-go::MirrorNodeAccountBalanceQuery").
 		Execute(env.Client)
 	require.NoError(t, err)
 	receipt, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
 	require.NoError(t, err)
 	contractID := *receipt.ContractID
 
-	// No SetContractID: a contract goes through account.id as the equivalent AccountID.
 	contractAccountID := AccountID{Shard: contractID.Shard, Realm: contractID.Realm, Account: contractID.Contract}
 
-	// Fund by transfer: the constructor is not payable, so an initial balance reverts.
 	tx, err := NewTransferTransaction().
 		AddHbarTransfer(contractAccountID, NewHbar(1)).
 		AddHbarTransfer(env.OperatorID, NewHbar(-1)).
@@ -200,8 +189,6 @@ func TestIntegrationMirrorNodeAccountBalanceQueryCanGetContractBalance(t *testin
 	require.NoError(t, err)
 }
 
-// Acceptance 5: an unknown account yields a zero balance, not an error -- the endpoint returns an
-// empty list rather than a 404, unlike the consensus-node query's INVALID_ACCOUNT_ID.
 func TestIntegrationMirrorNodeAccountBalanceQueryNonExistentAccountIsZero(t *testing.T) {
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)

--- a/sdk/mirror_node_account_balance_query_unit_test.go
+++ b/sdk/mirror_node_account_balance_query_unit_test.go
@@ -307,7 +307,7 @@ func TestUnitMirrorNodeAccountBalanceQueryResolveAttempts(t *testing.T) {
 	require.Equal(t, -1, client.GetMaxAttempts(), "an unset client reports -1, not a usable count")
 
 	query := NewMirrorNodeAccountBalanceQuery()
-	assert.Equal(t, uint64(maxAttempts), query.resolveAttempts(client), "falls back to the SDK default")
+	assert.Equal(t, uint64(mirrorNodeDefaultMaxAttempts), query.resolveAttempts(client), "falls back to the mirror node default")
 
 	client.SetMaxAttempts(4)
 	assert.Equal(t, uint64(4), query.resolveAttempts(client), "client setting is used when the query has none")
@@ -356,4 +356,66 @@ func TestUnitMirrorNodeAccountBalanceQueryWrapsTransportFailure(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to send request")
+}
+
+var errNotNil = errors.New("any error")
+
+// SetAccountID documents alias support, so an ID sent as an alias must not be checksum-validated —
+// an alias carries no checksum. An ID sent by number must still be validated, even if it also
+// carries an alias.
+func TestUnitMirrorNodeAccountBalanceQueryChecksumValidationAllowsAliases(t *testing.T) {
+	client := newMockMirrorClient(t, "aliaschecksum.example.com:443", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"balances":[{"balance":7}]}`))
+	})
+	client.SetAutoValidateChecksums(true)
+
+	key, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+	publicKey := key.PublicKey()
+	evmAccountID, err := AccountIDFromEvmPublicAddress("0x742d35Cc6634C0532925a3b844Bc454e4438f44e")
+	require.NoError(t, err)
+	goodChecksum, err := AccountIDFromString("0.0.123-esxsf")
+	require.NoError(t, err)
+	badChecksum, err := AccountIDFromString("0.0.123-rmkykd")
+	require.NoError(t, err)
+
+	numberAndEvmBadChecksum := badChecksum
+	numberAndEvmBadChecksum.AliasEvmAddress = evmAccountID.AliasEvmAddress
+
+	for _, tt := range []struct {
+		name      string
+		accountID AccountID
+		wantErr   error
+	}{
+		{name: "public key alias", accountID: AccountID{AliasKey: &publicKey}},
+		{name: "EVM address alias", accountID: evmAccountID},
+		{name: "numeric with valid checksum", accountID: goodChecksum},
+		{name: "numeric without checksum", accountID: AccountID{Account: 5}, wantErr: errChecksumMissing},
+		// Sent by number, so the checksum is still meaningful and still checked.
+		{name: "numeric with wrong checksum, carrying an EVM alias", accountID: numberAndEvmBadChecksum, wantErr: errNotNil},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewMirrorNodeAccountBalanceQuery().SetAccountID(tt.accountID).Execute(client)
+			switch {
+			case tt.wantErr == errNotNil:
+				require.Error(t, err)
+			case tt.wantErr != nil:
+				require.ErrorIs(t, err, tt.wantErr)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// A default query must not be able to block for minutes: 3 attempts at 30s each, and SetMaxAttempts
+// lets a caller tighten it further.
+func TestUnitMirrorNodeAccountBalanceQueryBoundsWallClockByDefault(t *testing.T) {
+	t.Parallel()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(3), uint64(mirrorNodeDefaultMaxAttempts), "3 attempts x 30s bounds the default")
+	assert.Equal(t, uint64(1), NewMirrorNodeAccountBalanceQuery().SetMaxAttempts(1).resolveAttempts(client))
 }

--- a/sdk/mirror_node_account_balance_query_unit_test.go
+++ b/sdk/mirror_node_account_balance_query_unit_test.go
@@ -48,7 +48,6 @@ func TestUnitMirrorNodeAccountBalanceQueryDefaults(t *testing.T) {
 	assert.Zero(t, query.GetMaxAttempts())
 }
 
-// AC 1: a valid account ID returns the hbar balance the mirror node reports.
 func TestUnitMirrorNodeAccountBalanceQueryReturnsHbarBalance(t *testing.T) {
 	var gotAccountID string
 	client := newMockMirrorClient(t, "balance.example.com:443", balancesHandler(t, &gotAccountID,
@@ -79,7 +78,6 @@ func TestUnitMirrorNodeAccountBalanceQueryLargeBalanceIsLossless(t *testing.T) {
 	assert.Equal(t, tinybars, balance.Hbars.AsTinybar())
 }
 
-// AC 2: an EVM address is sent as bare hex, which is what the mirror node resolves.
 func TestUnitMirrorNodeAccountBalanceQueryResolvesEvmAddress(t *testing.T) {
 	var gotAccountID string
 	client := newMockMirrorClient(t, "evm.example.com:443", balancesHandler(t, &gotAccountID,
@@ -97,7 +95,6 @@ func TestUnitMirrorNodeAccountBalanceQueryResolvesEvmAddress(t *testing.T) {
 	assert.Equal(t, "742d35cc6634c0532925a3b844bc454e4438f44e", gotAccountID)
 }
 
-// AC 3: a public key alias is sent base32-encoded, the form the mirror node reports and accepts.
 func TestUnitMirrorNodeAccountBalanceQueryResolvesPublicKeyAlias(t *testing.T) {
 	var gotAccountID string
 	client := newMockMirrorClient(t, "alias.example.com:443", balancesHandler(t, &gotAccountID,
@@ -119,7 +116,6 @@ func TestUnitMirrorNodeAccountBalanceQueryResolvesPublicKeyAlias(t *testing.T) {
 	assert.Equal(t, gotAccountID, url.QueryEscape(gotAccountID), "alias must need no escaping")
 }
 
-// AC 4: a contract is addressed through the same account.id parameter.
 func TestUnitMirrorNodeAccountBalanceQueryResolvesContractID(t *testing.T) {
 	var gotAccountID string
 	client := newMockMirrorClient(t, "contract.example.com:443", balancesHandler(t, &gotAccountID,
@@ -135,7 +131,6 @@ func TestUnitMirrorNodeAccountBalanceQueryResolvesContractID(t *testing.T) {
 	assert.Equal(t, "0.0.98765", gotAccountID)
 }
 
-// AC 5: an unknown account yields an empty list, which is a zero balance and not an error.
 func TestUnitMirrorNodeAccountBalanceQueryNonExistentAccountIsZero(t *testing.T) {
 	var gotAccountID string
 	client := newMockMirrorClient(t, "missing.example.com:443", balancesHandler(t, &gotAccountID,
@@ -149,7 +144,6 @@ func TestUnitMirrorNodeAccountBalanceQueryNonExistentAccountIsZero(t *testing.T)
 	assert.Equal(t, HbarFromTinybar(0), balance.Hbars)
 }
 
-// AC 6: an unset account ID fails before any network call.
 func TestUnitMirrorNodeAccountBalanceQueryNoAccountIDErrorsBeforeRequest(t *testing.T) {
 	var called atomic.Bool
 	client := newMockMirrorClient(t, "unused.example.com:443", func(w http.ResponseWriter, r *http.Request) {
@@ -173,7 +167,6 @@ func TestUnitMirrorNodeAccountBalanceQueryNilClientErrors(t *testing.T) {
 	require.ErrorIs(t, err, errNoClientProvided)
 }
 
-// AC 7: a transient 503 is retried and the following success is returned.
 func TestUnitMirrorNodeAccountBalanceQueryRetriesTransientError(t *testing.T) {
 	var attempts atomic.Int32
 	client := newMockMirrorClient(t, "retry.example.com:443", func(w http.ResponseWriter, r *http.Request) {
@@ -289,8 +282,7 @@ func TestUnitMirrorNodeAccountBalanceQueryBadChecksumErrorsBeforeRequest(t *test
 	assert.False(t, called.Load(), "a checksum mismatch must not reach the network")
 }
 
-// resolveAttempts: query setting, then client, then SDK default. The default must not be a single
-// attempt -- this query has to retry 5xx, and Client.GetMaxAttempts reports -1 when unset.
+// The fallback must not be a single attempt; 5xx responses still have to be retried.
 func TestUnitMirrorNodeAccountBalanceQueryResolveAttempts(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/mirror_node_account_balance_query_unit_test.go
+++ b/sdk/mirror_node_account_balance_query_unit_test.go
@@ -333,3 +333,19 @@ func TestUnitMirrorNodeAccountBalanceQueryBuildURL(t *testing.T) {
 	assert.Equal(t, "https://mirror.example.com/api/v1/balances?account.id=1.2.3",
 		query.buildURL("https://mirror.example.com/api/v1"))
 }
+
+func TestUnitMirrorNodeAccountBalanceQueryWrapsTransportFailure(t *testing.T) {
+	t.Parallel()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+	client.SetMirrorNetwork([]string{"127.0.0.1:1"})
+
+	_, err = NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{Account: 3}).
+		SetMaxAttempts(1).
+		Execute(client)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to send request")
+}

--- a/sdk/mirror_node_account_balance_query_unit_test.go
+++ b/sdk/mirror_node_account_balance_query_unit_test.go
@@ -1,0 +1,335 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// balancesHandler serves a /balances response, recording the account.id it was asked for.
+func balancesHandler(t *testing.T, gotAccountID *string, body string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/balances", r.URL.Path)
+		*gotAccountID = r.URL.Query().Get("account.id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+func TestUnitMirrorNodeAccountBalanceQueryGetSet(t *testing.T) {
+	t.Parallel()
+
+	accountID := AccountID{Shard: 1, Realm: 2, Account: 3}
+	query := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(accountID).
+		SetMaxAttempts(7)
+
+	assert.Equal(t, accountID, query.GetAccountID())
+	assert.Equal(t, uint64(7), query.GetMaxAttempts())
+}
+
+func TestUnitMirrorNodeAccountBalanceQueryDefaults(t *testing.T) {
+	t.Parallel()
+
+	query := NewMirrorNodeAccountBalanceQuery()
+
+	assert.Equal(t, AccountID{}, query.GetAccountID())
+	// Zero means unset; resolveAttempts supplies the effective value.
+	assert.Zero(t, query.GetMaxAttempts())
+}
+
+// AC 1: a valid account ID returns the hbar balance the mirror node reports.
+func TestUnitMirrorNodeAccountBalanceQueryReturnsHbarBalance(t *testing.T) {
+	var gotAccountID string
+	client := newMockMirrorClient(t, "balance.example.com:443", balancesHandler(t, &gotAccountID,
+		`{"timestamp":"1234567890.000000000","balances":[{"account":"0.0.12345","balance":123456789}],"links":{"next":null}}`))
+
+	balance, err := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{Account: 12345}).
+		Execute(client)
+
+	require.NoError(t, err)
+	assert.Equal(t, HbarFromTinybar(123456789), balance.Hbars)
+	assert.Equal(t, "0.0.12345", gotAccountID)
+}
+
+// Tinybars must survive values a float64 would round.
+func TestUnitMirrorNodeAccountBalanceQueryLargeBalanceIsLossless(t *testing.T) {
+	var gotAccountID string
+	// 2^53 + 1, the first integer float64 cannot represent exactly.
+	const tinybars int64 = 9007199254740993
+	client := newMockMirrorClient(t, "large.example.com:443", balancesHandler(t, &gotAccountID,
+		fmt.Sprintf(`{"balances":[{"account":"0.0.7","balance":%d}]}`, tinybars)))
+
+	balance, err := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{Account: 7}).
+		Execute(client)
+
+	require.NoError(t, err)
+	assert.Equal(t, tinybars, balance.Hbars.AsTinybar())
+}
+
+// AC 2: an EVM address is sent as bare hex, which is what the mirror node resolves.
+func TestUnitMirrorNodeAccountBalanceQueryResolvesEvmAddress(t *testing.T) {
+	var gotAccountID string
+	client := newMockMirrorClient(t, "evm.example.com:443", balancesHandler(t, &gotAccountID,
+		`{"balances":[{"account":"0.0.1001","balance":500}]}`))
+
+	accountID, err := AccountIDFromEvmAddress(0, 0, evmAddress)
+	require.NoError(t, err)
+
+	balance, err := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(accountID).
+		Execute(client)
+
+	require.NoError(t, err)
+	assert.Equal(t, HbarFromTinybar(500), balance.Hbars)
+	assert.Equal(t, "742d35cc6634c0532925a3b844bc454e4438f44e", gotAccountID)
+}
+
+// AC 3: a public key alias is sent base32-encoded, the form the mirror node reports and accepts.
+func TestUnitMirrorNodeAccountBalanceQueryResolvesPublicKeyAlias(t *testing.T) {
+	var gotAccountID string
+	client := newMockMirrorClient(t, "alias.example.com:443", balancesHandler(t, &gotAccountID,
+		`{"balances":[{"account":"0.0.2002","balance":42}]}`))
+
+	key, err := PrivateKeyFromStringEd25519(mockPrivateKey)
+	require.NoError(t, err)
+	publicKey := key.PublicKey()
+
+	balance, err := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{AliasKey: &publicKey}).
+		Execute(client)
+
+	require.NoError(t, err)
+	assert.Equal(t, HbarFromTinybar(42), balance.Hbars)
+	assert.NotEmpty(t, gotAccountID)
+	// Base32, never the DER hex AccountID.String() emits.
+	assert.NotContains(t, gotAccountID, "302a300506032b6570")
+	assert.Equal(t, gotAccountID, url.QueryEscape(gotAccountID), "alias must need no escaping")
+}
+
+// AC 4: a contract is addressed through the same account.id parameter.
+func TestUnitMirrorNodeAccountBalanceQueryResolvesContractID(t *testing.T) {
+	var gotAccountID string
+	client := newMockMirrorClient(t, "contract.example.com:443", balancesHandler(t, &gotAccountID,
+		`{"balances":[{"account":"0.0.98765","balance":777}]}`))
+
+	contractID := ContractID{Shard: 0, Realm: 0, Contract: 98765}
+	balance, err := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{Shard: contractID.Shard, Realm: contractID.Realm, Account: contractID.Contract}).
+		Execute(client)
+
+	require.NoError(t, err)
+	assert.Equal(t, HbarFromTinybar(777), balance.Hbars)
+	assert.Equal(t, "0.0.98765", gotAccountID)
+}
+
+// AC 5: an unknown account yields an empty list, which is a zero balance and not an error.
+func TestUnitMirrorNodeAccountBalanceQueryNonExistentAccountIsZero(t *testing.T) {
+	var gotAccountID string
+	client := newMockMirrorClient(t, "missing.example.com:443", balancesHandler(t, &gotAccountID,
+		`{"timestamp":null,"balances":[],"links":{"next":null}}`))
+
+	balance, err := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{Account: 999999999}).
+		Execute(client)
+
+	require.NoError(t, err, "an empty balances array is a zero balance, not an error")
+	assert.Equal(t, HbarFromTinybar(0), balance.Hbars)
+}
+
+// AC 6: an unset account ID fails before any network call.
+func TestUnitMirrorNodeAccountBalanceQueryNoAccountIDErrorsBeforeRequest(t *testing.T) {
+	var called atomic.Bool
+	client := newMockMirrorClient(t, "unused.example.com:443", func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	_, err := NewMirrorNodeAccountBalanceQuery().Execute(client)
+
+	require.ErrorIs(t, err, errMirrorNodeAccountBalanceQueryNoAccountID)
+	assert.False(t, called.Load(), "no request may be sent when the account ID is unset")
+}
+
+func TestUnitMirrorNodeAccountBalanceQueryNilClientErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{Account: 3}).
+		Execute(nil)
+
+	require.ErrorIs(t, err, errNoClientProvided)
+}
+
+// AC 7: a transient 503 is retried and the following success is returned.
+func TestUnitMirrorNodeAccountBalanceQueryRetriesTransientError(t *testing.T) {
+	var attempts atomic.Int32
+	client := newMockMirrorClient(t, "retry.example.com:443", func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"balances":[{"account":"0.0.5","balance":900}]}`))
+	})
+
+	balance, err := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{Account: 5}).
+		Execute(client)
+
+	require.NoError(t, err)
+	assert.Equal(t, HbarFromTinybar(900), balance.Hbars)
+	assert.Equal(t, int32(2), attempts.Load(), "the 503 should be retried exactly once")
+}
+
+// A 4xx is the intended answer and must not burn the retry budget.
+func TestUnitMirrorNodeAccountBalanceQueryDoesNotRetryClientError(t *testing.T) {
+	var attempts atomic.Int32
+	client := newMockMirrorClient(t, "badrequest.example.com:443", func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+	})
+
+	_, err := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{Account: 5}).
+		Execute(client)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+	assert.Equal(t, int32(1), attempts.Load(), "a 400 must not be retried")
+}
+
+func TestUnitMirrorNodeAccountBalanceQueryMalformedJSONErrors(t *testing.T) {
+	client := newMockMirrorClient(t, "garbage.example.com:443", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"balances":`))
+	})
+
+	_, err := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{Account: 5}).
+		Execute(client)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unmarshal response")
+}
+
+func TestUnitMirrorNodeAccountBalanceQueryNoMirrorNetworkErrors(t *testing.T) {
+	t.Parallel()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+	client.SetMirrorNetwork([]string{})
+
+	_, err = NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{Account: 3}).
+		Execute(client)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mirror node is not set")
+}
+
+// Checksum validation matches the consensus-node queries' validateNetworkOnIDs shape.
+func TestUnitMirrorNodeAccountBalanceQueryValidate(t *testing.T) {
+	t.Parallel()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+	client.SetLedgerID(*NewLedgerIDTestnet())
+	client.SetAutoValidateChecksums(true)
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
+	require.NoError(t, err)
+
+	query := NewMirrorNodeAccountBalanceQuery().SetAccountID(accountID)
+
+	require.NoError(t, query.validateNetworkOnIDs(client))
+}
+
+func TestUnitMirrorNodeAccountBalanceQueryValidateWrong(t *testing.T) {
+	t.Parallel()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+	client.SetLedgerID(*NewLedgerIDTestnet())
+	client.SetAutoValidateChecksums(true)
+	accountID, err := AccountIDFromString("0.0.123-rmkykd")
+	require.NoError(t, err)
+
+	query := NewMirrorNodeAccountBalanceQuery().SetAccountID(accountID)
+
+	err = query.validateNetworkOnIDs(client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "network mismatch or wrong checksum given")
+}
+
+// A bad checksum must stop Execute before any request reaches the mirror node.
+func TestUnitMirrorNodeAccountBalanceQueryBadChecksumErrorsBeforeRequest(t *testing.T) {
+	var called atomic.Bool
+	client := newMockMirrorClient(t, "checksum.example.com:443", func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		w.WriteHeader(http.StatusOK)
+	})
+	client.SetAutoValidateChecksums(true)
+	accountID, err := AccountIDFromString("0.0.123-rmkykd")
+	require.NoError(t, err)
+
+	_, err = NewMirrorNodeAccountBalanceQuery().SetAccountID(accountID).Execute(client)
+
+	require.Error(t, err)
+	assert.False(t, called.Load(), "a checksum mismatch must not reach the network")
+}
+
+// resolveAttempts: query setting, then client, then SDK default. The default must not be a single
+// attempt -- this query has to retry 5xx, and Client.GetMaxAttempts reports -1 when unset.
+func TestUnitMirrorNodeAccountBalanceQueryResolveAttempts(t *testing.T) {
+	t.Parallel()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+	require.Equal(t, -1, client.GetMaxAttempts(), "an unset client reports -1, not a usable count")
+
+	query := NewMirrorNodeAccountBalanceQuery()
+	assert.Equal(t, uint64(maxAttempts), query.resolveAttempts(client), "falls back to the SDK default")
+
+	client.SetMaxAttempts(4)
+	assert.Equal(t, uint64(4), query.resolveAttempts(client), "client setting is used when the query has none")
+
+	query.SetMaxAttempts(2)
+	assert.Equal(t, uint64(2), query.resolveAttempts(client), "the query setting wins")
+}
+
+// A client-level budget must reach the retry loop, not just resolveAttempts.
+func TestUnitMirrorNodeAccountBalanceQueryHonoursClientMaxAttempts(t *testing.T) {
+	var attempts atomic.Int32
+	client := newMockMirrorClient(t, "clientattempts.example.com:443", func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	client.SetMaxAttempts(2)
+
+	_, err := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{Account: 5}).
+		Execute(client)
+
+	require.Error(t, err)
+	assert.Equal(t, int32(2), attempts.Load(), "the client's budget of 2 bounds the retries")
+}
+
+func TestUnitMirrorNodeAccountBalanceQueryBuildURL(t *testing.T) {
+	t.Parallel()
+
+	query := NewMirrorNodeAccountBalanceQuery().SetAccountID(AccountID{Shard: 1, Realm: 2, Account: 3})
+
+	assert.Equal(t, "https://mirror.example.com/api/v1/balances?account.id=1.2.3",
+		query.buildURL("https://mirror.example.com/api/v1"))
+}

--- a/sdk/mirror_node_account_balance_query_unit_test.go
+++ b/sdk/mirror_node_account_balance_query_unit_test.go
@@ -5,6 +5,7 @@ package hiero
 // SPDX-License-Identifier: Apache-2.0
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -116,32 +117,47 @@ func TestUnitMirrorNodeAccountBalanceQueryResolvesPublicKeyAlias(t *testing.T) {
 	assert.Equal(t, gotAccountID, url.QueryEscape(gotAccountID), "alias must need no escaping")
 }
 
-func TestUnitMirrorNodeAccountBalanceQueryResolvesContractID(t *testing.T) {
-	var gotAccountID string
-	client := newMockMirrorClient(t, "contract.example.com:443", balancesHandler(t, &gotAccountID,
-		`{"balances":[{"account":"0.0.98765","balance":777}]}`))
-
-	contractID := ContractID{Shard: 0, Realm: 0, Contract: 98765}
-	balance, err := NewMirrorNodeAccountBalanceQuery().
-		SetAccountID(AccountID{Shard: contractID.Shard, Realm: contractID.Realm, Account: contractID.Contract}).
-		Execute(client)
-
-	require.NoError(t, err)
-	assert.Equal(t, HbarFromTinybar(777), balance.Hbars)
-	assert.Equal(t, "0.0.98765", gotAccountID)
-}
-
-func TestUnitMirrorNodeAccountBalanceQueryNonExistentAccountIsZero(t *testing.T) {
+func TestUnitMirrorNodeAccountBalanceQueryNonExistentAccountErrors(t *testing.T) {
 	var gotAccountID string
 	client := newMockMirrorClient(t, "missing.example.com:443", balancesHandler(t, &gotAccountID,
 		`{"timestamp":null,"balances":[],"links":{"next":null}}`))
 
-	balance, err := NewMirrorNodeAccountBalanceQuery().
+	_, err := NewMirrorNodeAccountBalanceQuery().
 		SetAccountID(AccountID{Account: 999999999}).
 		Execute(client)
 
-	require.NoError(t, err, "an empty balances array is a zero balance, not an error")
-	assert.Equal(t, HbarFromTinybar(0), balance.Hbars)
+	var status ErrHederaPreCheckStatus
+	require.ErrorAs(t, err, &status)
+	assert.Equal(t, StatusInvalidAccountID, status.Status)
+	assert.Contains(t, err.Error(), "INVALID_ACCOUNT_ID")
+}
+
+func TestUnitMirrorNodeAccountBalanceQueryZeroBalanceIsNotMissing(t *testing.T) {
+	var gotAccountID string
+	client := newMockMirrorClient(t, "zerobalance.example.com:443", balancesHandler(t, &gotAccountID,
+		`{"balances":[{"account":"0.0.42","balance":0}]}`))
+
+	balance, err := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{Account: 42}).
+		Execute(client)
+
+	require.NoError(t, err)
+	assert.Zero(t, balance.Hbars.AsTinybar())
+}
+
+func TestUnitMirrorNodeAccountBalanceQueryMissingBalancesArrayIsMalformed(t *testing.T) {
+	var gotAccountID string
+	client := newMockMirrorClient(t, "nobalances.example.com:443", balancesHandler(t, &gotAccountID,
+		`{"timestamp":null,"links":{"next":null}}`))
+
+	_, err := NewMirrorNodeAccountBalanceQuery().
+		SetAccountID(AccountID{Account: 7}).
+		Execute(client)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no balances array")
+	var status ErrHederaPreCheckStatus
+	assert.False(t, errors.As(err, &status), "a malformed payload must not read as a missing account")
 }
 
 func TestUnitMirrorNodeAccountBalanceQueryNoAccountIDErrorsBeforeRequest(t *testing.T) {

--- a/sdk/mirror_node_contract_query.go
+++ b/sdk/mirror_node_contract_query.go
@@ -4,8 +4,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"strconv"
 	"strings"
 
@@ -199,10 +197,7 @@ func (mirrorNodeContractQuery *mirrorNodeContractQuery) fillEvmAddresses() error
 }
 
 func (mirrorNodeContractQuery *mirrorNodeContractQuery) performContractCallToMirrorNode(client *Client, jsonPayload string) (map[string]any, error) {
-	if client.mirrorNetwork == nil || len(client.GetMirrorNetwork()) == 0 {
-		return nil, errors.New("mirror node is not set")
-	}
-	mirrorUrl, err := client.GetMirrorRestApiBaseUrl()
+	mirrorUrl, err := mirrorNodeRestBaseURL(client)
 	if err != nil {
 		return nil, err
 	}
@@ -218,18 +213,14 @@ func (mirrorNodeContractQuery *mirrorNodeContractQuery) performContractCallToMir
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
-	if resp == nil {
-		return nil, errors.New("received nil response from Mirror Node")
-	}
 
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("received non-200 response from Mirror Node: %d, details: %s", resp.StatusCode, body)
+	body, err := mirrorNodeReadBody(resp)
+	if err != nil {
+		return nil, err
 	}
 
 	var result map[string]any
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/sdk/mirror_node_contract_query_e2e_test.go
+++ b/sdk/mirror_node_contract_query_e2e_test.go
@@ -139,14 +139,14 @@ func TestMirrorNodeContractQueryFailWhenGasLimitIsLow(t *testing.T) {
 		SetGasLimit(100).
 		SetFunction("getOwner", nil).
 		Execute(env.Client)
-	require.ErrorContains(t, err, "received non-200 response from Mirror Node")
+	require.ErrorContains(t, err, "received non-200 response from mirror node")
 
 	_, err = NewMirrorNodeContractCallQuery().
 		SetContractID(*contractID).
 		SetGasLimit(100).
 		SetFunction("getOwner", nil).
 		Execute(env.Client)
-	require.ErrorContains(t, err, "received non-200 response from Mirror Node")
+	require.ErrorContains(t, err, "received non-200 response from mirror node")
 }
 
 func TestMirrorNodeContractQueryFailWhenSenderIsNotSet(t *testing.T) {
@@ -182,13 +182,13 @@ func TestMirrorNodeContractQueryFailWhenSenderIsNotSet(t *testing.T) {
 		SetContractID(*contractID).
 		SetFunction("addOwnerAndTransfer", param).
 		Execute(env.Client)
-	require.ErrorContains(t, err, "received non-200 response from Mirror Node")
+	require.ErrorContains(t, err, "received non-200 response from mirror node")
 
 	_, err = NewMirrorNodeContractCallQuery().
 		SetContractID(*contractID).
 		SetFunction("addOwnerAndTransfer", param).
 		Execute(env.Client)
-	require.ErrorContains(t, err, "received non-200 response from Mirror Node")
+	require.ErrorContains(t, err, "received non-200 response from mirror node")
 }
 func TestMirrorNodeContractQueryCanSimulateWithSenderSet(t *testing.T) {
 	env := NewIntegrationTestEnv(t)

--- a/sdk/mirror_node_contract_query_unit_test.go
+++ b/sdk/mirror_node_contract_query_unit_test.go
@@ -303,7 +303,7 @@ func TestUnitMirrorNodeContractQueryDoesNotRetryNon200(t *testing.T) {
 		SetContractEvmAddress("0x742d35Cc6634C0532925a3b844Bc454e4438f44e").
 		SetFunction("testFunction", NewContractFunctionParameters().AddString("test")).
 		Execute(client)
-	require.ErrorContains(t, err, "received non-200 response from Mirror Node")
+	require.ErrorContains(t, err, "received non-200 response from mirror node")
 	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts), "non-200 responses must not be retried")
 }
 

--- a/sdk/mirror_node_rest_helpers.go
+++ b/sdk/mirror_node_rest_helpers.go
@@ -25,8 +25,7 @@ const (
 )
 
 // mirrorNodeRestBaseURL returns the client's mirror node REST API base URL, erroring when no
-// mirror network is configured. A caller whose endpoint is served on a different port against a
-// local node overrides it afterwards.
+// mirror network is configured.
 func mirrorNodeRestBaseURL(client *Client) (string, error) {
 	if client == nil {
 		return "", errNoClientProvided

--- a/sdk/mirror_node_rest_helpers.go
+++ b/sdk/mirror_node_rest_helpers.go
@@ -4,7 +4,10 @@ package hiero
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/pkg/errors"
@@ -15,19 +18,56 @@ const (
 	mirrorNodeDefaultMaxAttempts = 3
 	// Per-request timeout for a mirror node call.
 	mirrorNodeDefaultTimeout = 30 * time.Second
+
+	// The only URL schemes a mirror node REST call can be made over.
+	mirrorNodeSchemeHTTP  = "http"
+	mirrorNodeSchemeHTTPS = "https"
 )
 
-// mirrorNodePostWithRetry POSTs to a mirror node REST/JSON-RPC endpoint, retrying transport
-// failures and 5xx/429 responses with exponential backoff. Genuine 4xx responses are the
-// intended result of the call and are not retried.
+// mirrorNodeRestBaseURL returns the client's mirror node REST API base URL, erroring when no
+// mirror network is configured.
 //
-// It returns the raw result of the final attempt so callers can format their own error:
-//   - success: non-nil response, StatusCode 200, Body open;
-//   - non-retryable/exhausted non-200: response with Body open and a nil error;
-//   - transport failure: nil response and the transport error.
+// The canonical value comes from _MirrorNode.getBaseRestUrl, which maps a localhost mirror network
+// to port 38081. Endpoints that a local node serves elsewhere override it afterwards: the fee
+// estimate and registered-node endpoints on 8084, the contract-call endpoint on 8545 (the JSON-RPC
+// relay). Callers that need no override use the returned URL as-is.
+func mirrorNodeRestBaseURL(client *Client) (string, error) {
+	if client == nil {
+		return "", errNoClientProvided
+	}
+	// The nil check is not redundant: GetMirrorNetwork dereferences the field.
+	if client.mirrorNetwork == nil || len(client.GetMirrorNetwork()) == 0 {
+		return "", errors.New("mirror node is not set")
+	}
+
+	return client.GetMirrorRestApiBaseUrl()
+}
+
+// mirrorNodeValidateURL rejects a URL no HTTP request could ever satisfy, so the retry loop does
+// not spend its whole budget and backoff on a permanent failure.
+func mirrorNodeValidateURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid mirror node URL %q: %w", rawURL, err)
+	}
+	if parsed.Scheme != mirrorNodeSchemeHTTP && parsed.Scheme != mirrorNodeSchemeHTTPS {
+		return fmt.Errorf("unsupported mirror node URL scheme %q in %q", parsed.Scheme, rawURL)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("mirror node URL %q has no host", rawURL)
+	}
+
+	return nil
+}
+
+// mirrorNodeRequestWithRetry runs send with exponential backoff, retrying transport failures and
+// 5xx/429; a 4xx is the intended result of the call and is not retried. send runs once per attempt
+// so it can rebuild the request body.
 //
-// The caller must close a non-nil Body. A timeout of 0 disables the per-request timeout.
-func mirrorNodePostWithRetry(client *Client, url, contentType string, body []byte, maxAttempts uint64, timeout time.Duration) (*http.Response, error) {
+// The final attempt is returned raw so callers can format their own error: a 200 response, a
+// non-200 response with a nil error, or a nil response and the transport error. The caller must
+// close a non-nil Body (mirrorNodeReadBody does). A timeout of 0 disables the per-request timeout.
+func mirrorNodeRequestWithRetry(client *Client, maxAttempts uint64, timeout time.Duration, send func(*http.Client) (*http.Response, error)) (*http.Response, error) {
 	if maxAttempts == 0 {
 		return nil, errors.New("maxAttempts must be at least 1")
 	}
@@ -38,7 +78,7 @@ func mirrorNodePostWithRetry(client *Client, url, contentType string, body []byt
 	var err error
 
 	for attempt := uint64(0); attempt < maxAttempts; attempt++ {
-		resp, err = httpClient.Post(url, contentType, bytes.NewBuffer(body)) // #nosec
+		resp, err = send(httpClient)
 
 		// Success or a non-retryable outcome is terminal; return the raw result.
 		if (err == nil && resp != nil && resp.StatusCode == http.StatusOK) || !mirrorNodeShouldRetry(err, resp) {
@@ -73,7 +113,18 @@ func mirrorNodePostWithRetry(client *Client, url, contentType string, body []byt
 	return resp, err
 }
 
-// mirrorNodeShouldRetry reports whether a failed POST should be retried: transport errors
+// mirrorNodePostWithRetry POSTs; see mirrorNodeRequestWithRetry for the retry contract.
+func mirrorNodePostWithRetry(client *Client, url, contentType string, body []byte, maxAttempts uint64, timeout time.Duration) (*http.Response, error) {
+	if err := mirrorNodeValidateURL(url); err != nil {
+		return nil, err
+	}
+
+	return mirrorNodeRequestWithRetry(client, maxAttempts, timeout, func(httpClient *http.Client) (*http.Response, error) {
+		return httpClient.Post(url, contentType, bytes.NewBuffer(body)) // #nosec
+	})
+}
+
+// mirrorNodeShouldRetry reports whether a failed request should be retried: transport errors
 // and 5xx/429 are transient; 4xx responses are genuine results the caller expects.
 func mirrorNodeShouldRetry(err error, resp *http.Response) bool {
 	if err == nil && resp != nil {
@@ -90,4 +141,83 @@ func mirrorNodeShouldRetry(err error, resp *http.Response) bool {
 	}
 
 	return true
+}
+
+// mirrorNodeReadBody closes the response body and turns a nil response or a non-200 status into an
+// error carrying the response details.
+func mirrorNodeReadBody(resp *http.Response) ([]byte, error) {
+	if resp == nil {
+		return nil, errors.New("received nil response from mirror node")
+	}
+	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		// Report the status even when the body could not be read; the status is the useful part.
+		if readErr != nil {
+			return nil, fmt.Errorf("received non-200 response from mirror node: %d, and its body could not be read: %w", resp.StatusCode, readErr)
+		}
+		return nil, fmt.Errorf("received non-200 response from mirror node: %d, details: %s", resp.StatusCode, body)
+	}
+	if readErr != nil {
+		return nil, fmt.Errorf("failed to read mirror node response: %w", readErr)
+	}
+
+	return body, nil
+}
+
+// mirrorNodeWalkPages walks a paginated endpoint from pageURL, passing each fetched body to
+// handlePage, which returns the raw links.next. Stops when next is absent, or at maxPages so a
+// misbehaving mirror node cannot loop forever.
+//
+// A links.next is a root-relative path, so it is resolved against pageURL itself rather than
+// against a separately supplied base -- one argument cannot then disagree with the other.
+func mirrorNodeWalkPages(
+	pageURL string,
+	maxPages int,
+	fetchPage func(pageURL string) ([]byte, error),
+	handlePage func(body []byte) (*string, error),
+) error {
+	base, err := url.Parse(pageURL)
+	if err != nil {
+		return fmt.Errorf("invalid mirror node page URL %q: %w", pageURL, err)
+	}
+
+	for range maxPages {
+		body, err := fetchPage(pageURL)
+		if err != nil {
+			return err
+		}
+
+		next, err := handlePage(body)
+		if err != nil {
+			return err
+		}
+
+		if next == nil || *next == "" {
+			return nil
+		}
+
+		resolved, err := resolveNextURL(base, *next)
+		if err != nil {
+			return fmt.Errorf("invalid pagination next link %q: %w", *next, err)
+		}
+		pageURL = resolved
+	}
+
+	return fmt.Errorf("exceeded pagination cap of %d pages", maxPages)
+}
+
+// resolveNextURL resolves a pagination next link against the mirror base URL.
+func resolveNextURL(base *url.URL, next string) (string, error) {
+	parsed, err := url.Parse(next)
+	if err != nil {
+		return "", err
+	}
+	return base.ResolveReference(parsed).String(), nil
+}
+
+// linksJSON is the pagination block on every paginated mirror node response.
+type linksJSON struct {
+	Next *string `json:"next"`
 }

--- a/sdk/mirror_node_rest_helpers.go
+++ b/sdk/mirror_node_rest_helpers.go
@@ -124,6 +124,17 @@ func mirrorNodePostWithRetry(client *Client, url, contentType string, body []byt
 	})
 }
 
+// mirrorNodeGetWithRetry GETs; see mirrorNodeRequestWithRetry for the retry contract.
+func mirrorNodeGetWithRetry(client *Client, url string, maxAttempts uint64, timeout time.Duration) (*http.Response, error) {
+	if err := mirrorNodeValidateURL(url); err != nil {
+		return nil, err
+	}
+
+	return mirrorNodeRequestWithRetry(client, maxAttempts, timeout, func(httpClient *http.Client) (*http.Response, error) {
+		return httpClient.Get(url) // #nosec
+	})
+}
+
 // mirrorNodeShouldRetry reports whether a failed request should be retried: transport errors
 // and 5xx/429 are transient; 4xx responses are genuine results the caller expects.
 func mirrorNodeShouldRetry(err error, resp *http.Response) bool {

--- a/sdk/mirror_node_rest_helpers.go
+++ b/sdk/mirror_node_rest_helpers.go
@@ -25,12 +25,8 @@ const (
 )
 
 // mirrorNodeRestBaseURL returns the client's mirror node REST API base URL, erroring when no
-// mirror network is configured.
-//
-// The canonical value comes from _MirrorNode.getBaseRestUrl, which maps a localhost mirror network
-// to port 38081. Endpoints that a local node serves elsewhere override it afterwards: the fee
-// estimate and registered-node endpoints on 8084, the contract-call endpoint on 8545 (the JSON-RPC
-// relay). Callers that need no override use the returned URL as-is.
+// mirror network is configured. A caller whose endpoint is served on a different port against a
+// local node overrides it afterwards.
 func mirrorNodeRestBaseURL(client *Client) (string, error) {
 	if client == nil {
 		return "", errNoClientProvided
@@ -43,8 +39,8 @@ func mirrorNodeRestBaseURL(client *Client) (string, error) {
 	return client.GetMirrorRestApiBaseUrl()
 }
 
-// mirrorNodeValidateURL rejects a URL no HTTP request could ever satisfy, so the retry loop does
-// not spend its whole budget and backoff on a permanent failure.
+// mirrorNodeValidateURL rejects a URL no HTTP request could satisfy, so the retry loop does not
+// spend its budget on a permanent failure.
 func mirrorNodeValidateURL(rawURL string) error {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
@@ -61,12 +57,9 @@ func mirrorNodeValidateURL(rawURL string) error {
 }
 
 // mirrorNodeRequestWithRetry runs send with exponential backoff, retrying transport failures and
-// 5xx/429; a 4xx is the intended result of the call and is not retried. send runs once per attempt
-// so it can rebuild the request body.
-//
-// The final attempt is returned raw so callers can format their own error: a 200 response, a
-// non-200 response with a nil error, or a nil response and the transport error. The caller must
-// close a non-nil Body (mirrorNodeReadBody does). A timeout of 0 disables the per-request timeout.
+// 5xx/429; a 4xx is the intended result and is not retried. The final attempt is returned raw so
+// callers can format their own error, and the caller must close a non-nil Body. A timeout of 0
+// disables the per-request timeout.
 func mirrorNodeRequestWithRetry(client *Client, maxAttempts uint64, timeout time.Duration, send func(*http.Client) (*http.Response, error)) (*http.Response, error) {
 	if maxAttempts == 0 {
 		return nil, errors.New("maxAttempts must be at least 1")
@@ -180,9 +173,6 @@ func mirrorNodeReadBody(resp *http.Response) ([]byte, error) {
 // mirrorNodeWalkPages walks a paginated endpoint from pageURL, passing each fetched body to
 // handlePage, which returns the raw links.next. Stops when next is absent, or at maxPages so a
 // misbehaving mirror node cannot loop forever.
-//
-// A links.next is a root-relative path, so it is resolved against pageURL itself rather than
-// against a separately supplied base -- one argument cannot then disagree with the other.
 func mirrorNodeWalkPages(
 	pageURL string,
 	maxPages int,

--- a/sdk/mirror_node_rest_helpers_unit_test.go
+++ b/sdk/mirror_node_rest_helpers_unit_test.go
@@ -176,7 +176,7 @@ func TestUnitMirrorNodeValidateURL(t *testing.T) {
 }
 
 // A URL no request could satisfy must fail before the retry loop spends its budget on it.
-func TestUnitMirrorNodeGetAndPostRejectInvalidURLWithoutRequesting(t *testing.T) {
+func TestUnitMirrorNodeGetAndPostRejectInvalidURL(t *testing.T) {
 	client, err := _NewMockClient()
 	require.NoError(t, err)
 
@@ -285,18 +285,18 @@ func TestUnitMirrorNodeWalkPagesFollowsNextAcrossPages(t *testing.T) {
 func TestUnitMirrorNodeWalkPagesStopsAtPageCap(t *testing.T) {
 	t.Parallel()
 
-	const cap = 3
+	const maxPages = 3
 	pages := 0
 	forever := "/api/v1/things?page=next"
 
-	err := mirrorNodeWalkPages("https://mirror.example.com/api/v1/things", cap,
+	err := mirrorNodeWalkPages("https://mirror.example.com/api/v1/things", maxPages,
 		func(pageURL string) ([]byte, error) { pages++; return []byte(`{}`), nil },
 		func(body []byte) (*string, error) { return &forever, nil },
 	)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeded pagination cap of 3 pages")
-	assert.Equal(t, cap, pages, "no more than the cap may be fetched")
+	assert.Equal(t, maxPages, pages, "no more than the cap may be fetched")
 }
 
 func TestUnitMirrorNodeWalkPagesPropagatesErrors(t *testing.T) {

--- a/sdk/mirror_node_rest_helpers_unit_test.go
+++ b/sdk/mirror_node_rest_helpers_unit_test.go
@@ -5,8 +5,10 @@ package hiero
 // SPDX-License-Identifier: Apache-2.0
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -121,4 +123,223 @@ func TestUnitMirrorNodePostWithRetryStopsOnNetworkUpdateCancellation(t *testing.
 	assert.ErrorIs(t, err, client.networkUpdateContext.Err())
 	assert.Nil(t, resp)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts), "backoff cancellation should stop before a second attempt")
+}
+
+func TestUnitMirrorNodeRestBaseURLRejectsNilClient(t *testing.T) {
+	t.Parallel()
+
+	_, err := mirrorNodeRestBaseURL(nil)
+	require.ErrorIs(t, err, errNoClientProvided)
+}
+
+func TestUnitMirrorNodeRestBaseURLRejectsEmptyMirrorNetwork(t *testing.T) {
+	t.Parallel()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+	client.SetMirrorNetwork([]string{})
+
+	_, err = mirrorNodeRestBaseURL(client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mirror node is not set")
+}
+
+func TestUnitMirrorNodeValidateURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		url     string
+		wantErr string
+	}{
+		{name: "https", url: "https://mirror.example.com/api/v1"},
+		{name: "http", url: "http://localhost:5551/api/v1"},
+		{name: "unparseable", url: "http://[::1", wantErr: "invalid mirror node URL"},
+		{name: "unsupported scheme", url: "ftp://mirror.example.com", wantErr: "unsupported mirror node URL scheme"},
+		{name: "no scheme", url: "mirror.example.com/api/v1", wantErr: "unsupported mirror node URL scheme"},
+		{name: "no host", url: "https:///api/v1", wantErr: "has no host"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := mirrorNodeValidateURL(tt.url)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// A URL no request could satisfy must fail before the retry loop spends its budget on it.
+func TestUnitMirrorNodeGetAndPostRejectInvalidURLWithoutRequesting(t *testing.T) {
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+
+	_, err = mirrorNodeGetWithRetry(client, "ftp://mirror.example.com", 3, time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported mirror node URL scheme")
+
+	_, err = mirrorNodePostWithRetry(client, "ftp://mirror.example.com", "application/json", []byte("{}"), 3, time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported mirror node URL scheme")
+}
+
+func TestUnitMirrorNodeReadBodyRejectsNilResponse(t *testing.T) {
+	t.Parallel()
+
+	_, err := mirrorNodeReadBody(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "received nil response from mirror node")
+}
+
+func TestUnitMirrorNodeReadBodyReportsNon200WithDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"_status":"invalid parameter"}`))
+	}))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL) // #nosec
+	require.NoError(t, err)
+
+	_, err = mirrorNodeReadBody(resp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+	assert.Contains(t, err.Error(), "invalid parameter")
+}
+
+func TestUnitMirrorNodeReadBodyReturnsBodyOn200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL) // #nosec
+	require.NoError(t, err)
+
+	body, err := mirrorNodeReadBody(resp)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"ok":true}`, string(body))
+}
+
+// The happy paths live in registered_node_address_book_query_unit_test.go; this is the error branch.
+func TestUnitResolveNextURLRejectsUnparseableLink(t *testing.T) {
+	t.Parallel()
+
+	base, err := url.Parse("https://mirror.example.com/api/v1/things")
+	require.NoError(t, err)
+
+	_, err = resolveNextURL(base, "://nope")
+	require.Error(t, err)
+}
+
+func TestUnitMirrorNodeWalkPagesStopsWhenNextIsAbsent(t *testing.T) {
+	t.Parallel()
+
+	var fetched []string
+	err := mirrorNodeWalkPages("https://mirror.example.com/api/v1/things", 10,
+		func(pageURL string) ([]byte, error) {
+			fetched = append(fetched, pageURL)
+			return []byte(`{}`), nil
+		},
+		func(body []byte) (*string, error) { return nil, nil },
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"https://mirror.example.com/api/v1/things"}, fetched)
+}
+
+func TestUnitMirrorNodeWalkPagesFollowsNextAcrossPages(t *testing.T) {
+	t.Parallel()
+
+	next := []string{"/api/v1/things?page=2", "/api/v1/things?page=3", ""}
+	var fetched []string
+	page := 0
+
+	err := mirrorNodeWalkPages("https://mirror.example.com/api/v1/things", 10,
+		func(pageURL string) ([]byte, error) {
+			fetched = append(fetched, pageURL)
+			return []byte(`{}`), nil
+		},
+		func(body []byte) (*string, error) {
+			n := next[page]
+			page++
+			return &n, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"https://mirror.example.com/api/v1/things",
+		"https://mirror.example.com/api/v1/things?page=2",
+		"https://mirror.example.com/api/v1/things?page=3",
+	}, fetched, "each links.next is resolved against the base and fetched in order")
+}
+
+// The cap is what stops a mirror node that always returns a next link from looping forever.
+func TestUnitMirrorNodeWalkPagesStopsAtPageCap(t *testing.T) {
+	t.Parallel()
+
+	const cap = 3
+	pages := 0
+	forever := "/api/v1/things?page=next"
+
+	err := mirrorNodeWalkPages("https://mirror.example.com/api/v1/things", cap,
+		func(pageURL string) ([]byte, error) { pages++; return []byte(`{}`), nil },
+		func(body []byte) (*string, error) { return &forever, nil },
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeded pagination cap of 3 pages")
+	assert.Equal(t, cap, pages, "no more than the cap may be fetched")
+}
+
+func TestUnitMirrorNodeWalkPagesPropagatesErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid start URL", func(t *testing.T) {
+		t.Parallel()
+		err := mirrorNodeWalkPages("://nope", 10,
+			func(string) ([]byte, error) { return nil, nil },
+			func([]byte) (*string, error) { return nil, nil },
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid mirror node page URL")
+	})
+
+	t.Run("fetch failure", func(t *testing.T) {
+		t.Parallel()
+		err := mirrorNodeWalkPages("https://mirror.example.com/api/v1/things", 10,
+			func(string) ([]byte, error) { return nil, errors.New("boom") },
+			func([]byte) (*string, error) { return nil, nil },
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "boom")
+	})
+
+	t.Run("handler failure", func(t *testing.T) {
+		t.Parallel()
+		err := mirrorNodeWalkPages("https://mirror.example.com/api/v1/things", 10,
+			func(string) ([]byte, error) { return []byte(`{}`), nil },
+			func([]byte) (*string, error) { return nil, errors.New("bad page") },
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bad page")
+	})
+
+	t.Run("invalid next link", func(t *testing.T) {
+		t.Parallel()
+		bad := "://nope"
+		err := mirrorNodeWalkPages("https://mirror.example.com/api/v1/things", 10,
+			func(string) ([]byte, error) { return []byte(`{}`), nil },
+			func([]byte) (*string, error) { return &bad, nil },
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid pagination next link")
+	})
 }

--- a/sdk/registered_node_address_book_query.go
+++ b/sdk/registered_node_address_book_query.go
@@ -85,36 +85,28 @@ func (q *RegisteredNodeAddressBookQuery) Execute(client *Client) (RegisteredNode
 		return RegisteredNodeAddressBook{}, errNoClientProvided
 	}
 
-	mirrorBase, endpoint, err := q.resolveEndpoint(client)
+	endpoint, err := q.resolveEndpoint(client)
 	if err != nil {
 		return RegisteredNodeAddressBook{}, err
 	}
 
-	return q.walkPages(mirrorBase, endpoint, q.resolveAttempts(client))
+	return q.walkPages(endpoint, q.resolveAttempts(client))
 }
 
-// resolveEndpoint discovers the mirror node REST base URL on the client,
-// parses it, and returns it together with the initial query URL.
-func (q *RegisteredNodeAddressBookQuery) resolveEndpoint(client *Client) (*url.URL, string, error) {
-	if client.mirrorNetwork == nil || len(client.GetMirrorNetwork()) == 0 {
-		return nil, "", fmt.Errorf("mirror node is not set")
-	}
-
-	mirrorUrl, err := client.GetMirrorRestApiBaseUrl()
+// resolveEndpoint discovers the mirror node REST base URL on the client and
+// returns the initial query URL. A local node serves this endpoint on 8084
+// rather than the default mirrorNodeRestBaseURL port.
+func (q *RegisteredNodeAddressBookQuery) resolveEndpoint(client *Client) (string, error) {
+	mirrorUrl, err := mirrorNodeRestBaseURL(client)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get mirror REST API base URL: %w", err)
+		return "", err
 	}
 
 	if strings.Contains(mirrorUrl, "localhost") || strings.Contains(mirrorUrl, "127.0.0.1") {
 		mirrorUrl = "http://localhost:8084/api/v1"
 	}
 
-	mirrorBase, err := url.Parse(mirrorUrl)
-	if err != nil {
-		return nil, "", fmt.Errorf("invalid mirror REST API base URL %q: %w", mirrorUrl, err)
-	}
-
-	return mirrorBase, q.buildURL(mirrorUrl), nil
+	return q.buildURL(mirrorUrl), nil
 }
 
 // resolveAttempts picks the per-page retry budget: query setting first,
@@ -130,33 +122,29 @@ func (q *RegisteredNodeAddressBookQuery) resolveAttempts(client *Client) uint64 
 }
 
 // walkPages follows links.next until exhausted (or the page cap trips).
-func (q *RegisteredNodeAddressBookQuery) walkPages(base *url.URL, endpoint string, attempts uint64) (RegisteredNodeAddressBook, error) {
+func (q *RegisteredNodeAddressBookQuery) walkPages(endpoint string, attempts uint64) (RegisteredNodeAddressBook, error) {
 	allNodes := make([]RegisteredNode, 0)
 
-	for range registeredNodeMaxPages {
-		body, err := fetchRegisteredNodesPage(endpoint, attempts)
-		if err != nil {
-			return RegisteredNodeAddressBook{}, err
-		}
-
-		nodes, next, err := parseRegisteredNodes(body)
-		if err != nil {
-			return RegisteredNodeAddressBook{}, err
-		}
-		allNodes = append(allNodes, nodes...)
-
-		if next == nil || *next == "" {
-			return RegisteredNodeAddressBook{RegisteredNodes: allNodes}, nil
-		}
-
-		resolved, err := resolveNextURL(base, *next)
-		if err != nil {
-			return RegisteredNodeAddressBook{}, fmt.Errorf("invalid pagination next link %q: %w", *next, err)
-		}
-		endpoint = resolved
+	err := mirrorNodeWalkPages(
+		endpoint,
+		registeredNodeMaxPages,
+		func(pageURL string) ([]byte, error) {
+			return fetchRegisteredNodesPage(pageURL, attempts)
+		},
+		func(body []byte) (*string, error) {
+			nodes, next, err := parseRegisteredNodes(body)
+			if err != nil {
+				return nil, err
+			}
+			allNodes = append(allNodes, nodes...)
+			return next, nil
+		},
+	)
+	if err != nil {
+		return RegisteredNodeAddressBook{}, err
 	}
 
-	return RegisteredNodeAddressBook{}, fmt.Errorf("exceeded pagination cap of %d pages", registeredNodeMaxPages)
+	return RegisteredNodeAddressBook{RegisteredNodes: allNodes}, nil
 }
 
 // buildURL composes the mirror node REST URL together with any query
@@ -222,15 +210,6 @@ func fetchRegisteredNodesPage(endpoint string, attempts uint64) ([]byte, error) 
 	return nil, fmt.Errorf("failed after %d attempt(s): %w", attempts, lastErr)
 }
 
-// resolveNextURL resolves a pagination next link against the mirror base URL.
-func resolveNextURL(base *url.URL, next string) (string, error) {
-	parsed, err := url.Parse(next)
-	if err != nil {
-		return "", err
-	}
-	return base.ResolveReference(parsed).String(), nil
-}
-
 func parseRegisteredNodes(body []byte) ([]RegisteredNode, *string, error) {
 	var raw registeredNodesResponseJSON
 	if err := json.Unmarshal(body, &raw); err != nil {
@@ -256,10 +235,6 @@ func parseRegisteredNodes(body []byte) ([]RegisteredNode, *string, error) {
 type registeredNodesResponseJSON struct {
 	RegisteredNodes []registeredNodeJSON `json:"registered_nodes"`
 	Links           *linksJSON           `json:"links"`
-}
-
-type linksJSON struct {
-	Next *string `json:"next"`
 }
 
 type registeredNodeJSON struct {

--- a/sdk/registered_node_address_book_query.go
+++ b/sdk/registered_node_address_book_query.go
@@ -93,9 +93,8 @@ func (q *RegisteredNodeAddressBookQuery) Execute(client *Client) (RegisteredNode
 	return q.walkPages(endpoint, q.resolveAttempts(client))
 }
 
-// resolveEndpoint discovers the mirror node REST base URL on the client and
-// returns the initial query URL. A local node serves this endpoint on 8084
-// rather than the default mirrorNodeRestBaseURL port.
+// resolveEndpoint returns the initial query URL. A local node serves this
+// endpoint on 8084 rather than on the client's mirror REST port.
 func (q *RegisteredNodeAddressBookQuery) resolveEndpoint(client *Client) (string, error) {
 	mirrorUrl, err := mirrorNodeRestBaseURL(client)
 	if err != nil {

--- a/sdk/registered_node_address_book_query_unit_test.go
+++ b/sdk/registered_node_address_book_query_unit_test.go
@@ -6,6 +6,8 @@ package hiero
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
@@ -420,4 +422,66 @@ func TestUnitRegisteredNodeAddressBookQueryExecuteNoMirror(t *testing.T) {
 	_, err = NewRegisteredNodeAddressBookQuery().Execute(client)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mirror node is not set")
+}
+
+// A local mirror serves this endpoint on 8084 rather than the default REST port.
+func TestUnitRegisteredNodeAddressBookQueryResolveEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mirror  string
+		wantPre string
+	}{
+		{name: "localhost is redirected to 8084", mirror: "localhost:5600", wantPre: "http://localhost:8084/api/v1/network/registered-nodes"},
+		{name: "loopback IP is redirected to 8084", mirror: "127.0.0.1:5600", wantPre: "http://localhost:8084/api/v1/network/registered-nodes"},
+		{name: "remote mirror is left alone", mirror: "mirror.example.com:443", wantPre: "https://mirror.example.com:443/api/v1/network/registered-nodes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, err := _NewMockClient()
+			require.NoError(t, err)
+			client.SetMirrorNetwork([]string{tt.mirror})
+
+			endpoint, err := NewRegisteredNodeAddressBookQuery().resolveEndpoint(client)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPre, endpoint)
+		})
+	}
+}
+
+func TestUnitRegisteredNodeAddressBookQueryWalkPagesAccumulates(t *testing.T) {
+	page := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page++
+		if page == 1 {
+			_, _ = w.Write([]byte(`{"registered_nodes":[{"registered_node_id":1,"description":"one"}],"links":{"next":"/api/v1/network/registered-nodes?page=2"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"registered_nodes":[{"registered_node_id":2,"description":"two"}],"links":{"next":null}}`))
+	}))
+	defer server.Close()
+
+	book, err := NewRegisteredNodeAddressBookQuery().walkPages(server.URL, 1)
+
+	require.NoError(t, err)
+	require.Len(t, book.RegisteredNodes, 2, "nodes from every page are accumulated")
+	assert.Equal(t, uint64(1), book.RegisteredNodes[0].RegisteredNodeID)
+	assert.Equal(t, uint64(2), book.RegisteredNodes[1].RegisteredNodeID)
+}
+
+func TestUnitRegisteredNodeAddressBookQueryWalkPagesSurfacesHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"_status":"bad"}`))
+	}))
+	defer server.Close()
+
+	_, err := NewRegisteredNodeAddressBookQuery().walkPages(server.URL, 1)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
 }

--- a/sdk/utilities_for_test.go
+++ b/sdk/utilities_for_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
@@ -473,4 +474,23 @@ func SetupMockTransportForDomain(domain string, mockServerURL string) func() {
 	return func() {
 		http.DefaultTransport = originalTransport
 	}
+}
+
+// newMockMirrorClient serves handler from a test server, redirects domain to it, and returns a
+// client whose mirror network is that domain. The server and the transport redirect are torn down
+// through t.Cleanup; because the redirect mutates http.DefaultTransport, callers must not be
+// parallel.
+func newMockMirrorClient(t *testing.T, domain string, handler http.HandlerFunc) *Client {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	t.Cleanup(SetupMockTransportForDomain(domain, server.URL))
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+	client.SetLedgerID(*NewLedgerIDTestnet())
+	client.SetMirrorNetwork([]string{domain})
+
+	return client
 }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

The consensus node stops serving `CryptoService/cryptoGetBalance` in release 0.77, which retires
`AccountBalanceQuery`. Add its mirror node replacement, built to the merged
[migration proposal](https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/proposals/account-balance-query-mirror-node-migration.md).

* Add `MirrorNodeAccountBalanceQuery`, reading `GET /api/v1/balances?account.id={id}`
* Add `MirrorNodeAccountBalance`, carrying the hbar balance
* Add `AccountID._MirrorNodePathID` so an EVM-address alias is sent as bare hex and a public key
  alias as unpadded base32, and route the existing `_MirrorNodeRequest` through it
* Consolidate the mirror node REST calls onto one retry core and move `FeeEstimateQuery`,
  `MirrorNodeContractQuery` and `RegisteredNodeAddressBookQuery` onto it
* Add an example under `examples/mirror_node_account_balance`
* Fix a nil-pointer panic in `PopulateAccount`: it dereferenced `*id.AliasEvmAddress` unconditionally, so it
  panicked on any `AccountID` without an EVM alias.
* Skip checksum validation for IDs sent as an alias — an alias has no checksum, so
    validating one rejected the EVM-address and public-key forms SetAccountID documents
* Default the retry budget to the mirror node's 3 attempts instead of 10, capping a
    failing query at ~91s instead of ~5.7 minutes

**Related issue(s)**:

Fixes #1792

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
