### PR TITLE
chore: scope the SA1019 exclusion to protobuf deprecations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,11 @@ linters:
                 - "-QF1008" # Omit embedded fields from selector expression.
     exclusions:
         generated: lax
+        rules:
+            # The SDK must keep reading protobuf fields HAPI marks deprecated.
+            - linters:
+                  - staticcheck
+              text: "SA1019: .*is deprecated: Marked as deprecated in .*\\.proto"
         presets:
             - comments
             - common-false-positives


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
Golangci-lint v2.13.0 began reporting SA1019 for HAPI protobuf fields the SDK must keep reading for wire compatibility, turning CI red on every branch. Exclude those findings without disabling deprecation reporting for the SDK's other dependencies.
* Exclude SA1019 for protobuf-origin deprecations via a scoped exclusion rule

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
