### PR TITLE
fix: derive TokenID.equals from TokenID.Compare

### DIFF
--- a/sdk/token_airdrop_transaction_e2e_test.go
+++ b/sdk/token_airdrop_transaction_e2e_test.go
@@ -495,3 +495,38 @@ func TestIntegrationTokenAirdropTransactionWithInvalidBody(t *testing.T) {
 		Execute(env.Client)
 	require.ErrorContains(t, err, "INVALID_TRANSACTION_BODY")
 }
+
+func TestIntegrationTokenAirdropTransactionTransfersMultipleTokensIndependently(t *testing.T) {
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	tokenA, err := createFungibleToken(&env)
+	require.NoError(t, err)
+	tokenB, err := createFungibleToken(&env)
+	require.NoError(t, err)
+
+	receiver, _, err := createAccount(&env, func(tx *AccountCreateTransaction) {
+		tx.SetMaxAutomaticTokenAssociations(-1)
+	})
+	require.NoError(t, err)
+
+	// Distinct amounts per token so the record attributes each movement unambiguously.
+	airdropTx, err := NewTokenAirdropTransaction().
+		AddTokenTransfer(tokenA, env.OperatorID, -100).
+		AddTokenTransfer(tokenA, receiver, 100).
+		AddTokenTransfer(tokenB, env.OperatorID, -50).
+		AddTokenTransfer(tokenB, receiver, 50).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	record, err := airdropTx.SetValidateStatus(true).GetRecord(env.Client)
+	require.NoError(t, err)
+
+	// Each token must move its own amount, and neither may absorb the other.
+	require.Contains(t, record.TokenTransfers, tokenA)
+	require.Contains(t, record.TokenTransfers, tokenB)
+	assert.Equal(t, int64(100), tokenTransferAmountFor(t, record.TokenTransfers[tokenA], receiver))
+	assert.Equal(t, int64(-100), tokenTransferAmountFor(t, record.TokenTransfers[tokenA], env.OperatorID))
+	assert.Equal(t, int64(50), tokenTransferAmountFor(t, record.TokenTransfers[tokenB], receiver))
+	assert.Equal(t, int64(-50), tokenTransferAmountFor(t, record.TokenTransfers[tokenB], env.OperatorID))
+}

--- a/sdk/token_airdrop_transaction_unit_test.go
+++ b/sdk/token_airdrop_transaction_unit_test.go
@@ -340,3 +340,135 @@ func TestUnitTokenAirdropTransactionFromToBytes(t *testing.T) {
 
 	assert.Equal(t, tx.buildProtoBody(), txFromBytes.(TokenAirdropTransaction).buildProtoBody())
 }
+
+func TestUnitTokenAirdropTransactionAddTokenTransferMultipleTokens(t *testing.T) {
+	t.Parallel()
+
+	tokenA := TokenID{Token: 1}
+	tokenB := TokenID{Token: 2}
+	sender := AccountID{Account: 2}
+	receiver := AccountID{Account: 3}
+
+	transaction := NewTokenAirdropTransaction().
+		AddTokenTransfer(tokenA, sender, -100).
+		AddTokenTransfer(tokenA, receiver, 100).
+		AddTokenTransfer(tokenB, sender, -50).
+		AddTokenTransfer(tokenB, receiver, 50)
+
+	transfers := transaction.GetTokenTransfers()
+	require.Contains(t, transfers, tokenA)
+	require.Contains(t, transfers, tokenB)
+	require.Len(t, transfers[tokenA], 2)
+	require.Len(t, transfers[tokenB], 2)
+
+	assert.Equal(t, int64(-100), tokenTransferAmountFor(t, transfers[tokenA], sender))
+	assert.Equal(t, int64(100), tokenTransferAmountFor(t, transfers[tokenA], receiver))
+	assert.Equal(t, int64(-50), tokenTransferAmountFor(t, transfers[tokenB], sender))
+	assert.Equal(t, int64(50), tokenTransferAmountFor(t, transfers[tokenB], receiver))
+}
+
+func TestUnitTokenAirdropTransactionAddTokenTransferWithDecimalsMultipleTokens(t *testing.T) {
+	t.Parallel()
+
+	tokenA := TokenID{Token: 1}
+	tokenB := TokenID{Token: 2}
+	sender := AccountID{Account: 2}
+
+	transaction := NewTokenAirdropTransaction().
+		AddTokenTransferWithDecimals(tokenA, sender, -100, 8).
+		AddTokenTransferWithDecimals(tokenB, sender, -50, 2)
+
+	transfers := transaction.GetTokenTransfers()
+	require.Contains(t, transfers, tokenA)
+	require.Contains(t, transfers, tokenB)
+	assert.Equal(t, int64(-100), tokenTransferAmountFor(t, transfers[tokenA], sender))
+	assert.Equal(t, int64(-50), tokenTransferAmountFor(t, transfers[tokenB], sender))
+
+	decimals := transaction.GetTokenIDDecimals()
+	assert.Equal(t, uint32(8), decimals[tokenA])
+	assert.Equal(t, uint32(2), decimals[tokenB])
+}
+
+func TestUnitTokenAirdropTransactionAddApprovedTokenTransferMultipleTokens(t *testing.T) {
+	t.Parallel()
+
+	tokenA := TokenID{Token: 1}
+	tokenB := TokenID{Token: 2}
+	sender := AccountID{Account: 2}
+
+	transaction := NewTokenAirdropTransaction().
+		AddApprovedTokenTransfer(tokenA, sender, -100, true).
+		AddApprovedTokenTransfer(tokenB, sender, -50, false)
+
+	transfers := transaction.GetTokenTransfers()
+	require.Len(t, transfers[tokenA], 1)
+	require.Len(t, transfers[tokenB], 1)
+	assert.Equal(t, int64(-100), transfers[tokenA][0].Amount)
+	assert.Equal(t, int64(-50), transfers[tokenB][0].Amount)
+	assert.True(t, transfers[tokenA][0].IsApproved)
+	assert.False(t, transfers[tokenB][0].IsApproved, "approval must not leak from tokenA to tokenB")
+}
+
+func TestUnitTokenAirdropTransactionAddApprovedTokenTransferWithDecimalsMultipleTokens(t *testing.T) {
+	t.Parallel()
+
+	tokenA := TokenID{Token: 1}
+	tokenB := TokenID{Token: 2}
+	sender := AccountID{Account: 2}
+
+	transaction := NewTokenAirdropTransaction().
+		AddApprovedTokenTransferWithDecimals(tokenA, sender, -100, 8, true).
+		AddApprovedTokenTransferWithDecimals(tokenB, sender, -50, 2, false)
+
+	decimals := transaction.GetTokenIDDecimals()
+	assert.Equal(t, uint32(8), decimals[tokenA])
+	assert.Equal(t, uint32(2), decimals[tokenB])
+
+	transfers := transaction.GetTokenTransfers()
+	require.Len(t, transfers[tokenA], 1)
+	require.Len(t, transfers[tokenB], 1)
+	assert.Equal(t, int64(-100), transfers[tokenA][0].Amount)
+	assert.Equal(t, int64(-50), transfers[tokenB][0].Amount)
+	assert.True(t, transfers[tokenA][0].IsApproved)
+	assert.False(t, transfers[tokenB][0].IsApproved, "approval must not leak from tokenA to tokenB")
+}
+
+func TestUnitTokenAirdropTransactionSetTokenTransferApprovalOtherTokensUnaffected(t *testing.T) {
+	t.Parallel()
+
+	tokenA := TokenID{Token: 1}
+	tokenB := TokenID{Token: 2}
+	sender := AccountID{Account: 2}
+
+	transaction := NewTokenAirdropTransaction().
+		AddTokenTransfer(tokenA, sender, -100).
+		AddTokenTransfer(tokenB, sender, -50).
+		SetTokenTransferApproval(tokenA, sender, true)
+
+	transfers := transaction.GetTokenTransfers()
+	require.Len(t, transfers[tokenA], 1)
+	require.Len(t, transfers[tokenB], 1)
+	assert.True(t, transfers[tokenA][0].IsApproved)
+	assert.False(t, transfers[tokenB][0].IsApproved, "approval must not leak to the token that was not named")
+}
+
+func TestUnitTokenAirdropTransactionSetNftTransferApprovalOtherTokensUnaffected(t *testing.T) {
+	t.Parallel()
+
+	// Serial numbers restart at 1 for every collection, so serial 1 exists in both.
+	tokenA := TokenID{Token: 1}
+	tokenB := TokenID{Token: 2}
+	sender := AccountID{Account: 2}
+	receiver := AccountID{Account: 3}
+
+	transaction := NewTokenAirdropTransaction().
+		AddNftTransfer(NftID{TokenID: tokenA, SerialNumber: 1}, sender, receiver).
+		AddNftTransfer(NftID{TokenID: tokenB, SerialNumber: 1}, sender, receiver).
+		SetNftTransferApproval(NftID{TokenID: tokenA, SerialNumber: 1}, true)
+
+	nftTransfers := transaction.GetNftTransfers()
+	require.Len(t, nftTransfers[tokenA], 1)
+	require.Len(t, nftTransfers[tokenB], 1)
+	assert.True(t, nftTransfers[tokenA][0].IsApproved)
+	assert.False(t, nftTransfers[tokenB][0].IsApproved, "approval must not leak to the collection that was not named")
+}

--- a/sdk/token_id.go
+++ b/sdk/token_id.go
@@ -193,7 +193,7 @@ func (id TokenID) _IsZero() bool {
 
 // equals returns true if this TokenID and the given TokenID are identical
 func (id TokenID) equals(other TokenID) bool {
-	return id.Shard == other.Shard && id.Realm == other.Realm
+	return id.Compare(other) == 0
 }
 
 // Compare compares two TokenIDs

--- a/sdk/token_id_unit_test.go
+++ b/sdk/token_id_unit_test.go
@@ -156,3 +156,19 @@ func TestUnitTokenIDToEvmAddress(t *testing.T) {
 	id = TokenID{Shard: 1, Realm: 1, Token: 123}
 	require.Equal(t, longZeroAddress, id.ToEvmAddress())
 }
+func TestUnitTokenIDEqualsDistinguishesEveryField(t *testing.T) {
+	t.Parallel()
+
+	base := TokenID{Shard: 1, Realm: 2, Token: 3}
+
+	assert.True(t, base.equals(TokenID{Shard: 1, Realm: 2, Token: 3}))
+	assert.False(t, base.equals(TokenID{Shard: 9, Realm: 2, Token: 3}), "shard must be significant")
+	assert.False(t, base.equals(TokenID{Shard: 1, Realm: 9, Token: 3}), "realm must be significant")
+	assert.False(t, base.equals(TokenID{Shard: 1, Realm: 2, Token: 9}), "token number must be significant")
+
+	assert.False(t, TokenID{Token: 1000}.equals(TokenID{Token: 2000}))
+
+	// A checksum is presentation metadata and must not affect identity.
+	checksum := "abcde"
+	assert.True(t, base.equals(TokenID{Shard: 1, Realm: 2, Token: 3, checksum: &checksum}))
+}

--- a/sdk/utilities_for_test.go
+++ b/sdk/utilities_for_test.go
@@ -494,3 +494,16 @@ func newMockMirrorClient(t *testing.T, domain string, handler http.HandlerFunc) 
 
 	return client
 }
+
+// tokenTransferAmountFor returns the amount transferred for accountID, failing the
+// test if no transfer matches.
+func tokenTransferAmountFor(t *testing.T, transfers []TokenTransfer, accountID AccountID) int64 {
+	t.Helper()
+	for _, transfer := range transfers {
+		if transfer.AccountID.Compare(accountID) == 0 {
+			return transfer.Amount
+		}
+	}
+	t.Fatalf("no transfer found for account %s", accountID)
+	return 0
+}


### PR DESCRIPTION
**Description**:

Fix `TokenAirdropTransaction` matching tokens with a comparison that ignored the token
number, so an airdrop carrying more than one token could attribute one token's transfers to
another. `TransferTransaction` was unaffected — it already compares full token IDs.

* Derive `TokenID.equals` from `TokenID.Compare` so the two cannot disagree
* Add multi-token unit coverage for each of the six builder loops that match on token ID
* Add a multi-token airdrop integration test asserting on the transaction record
* Move the shared token-transfer amount helper into `utilities_for_test.go`

**Related issue(s)**:

Fixes #1805
**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
