### PR TITLE
refactor: remove constructScheduleProtobuf from TransactionInterface

### DIFF
--- a/sdk/account_allowance_approve_transaction.go
+++ b/sdk/account_allowance_approve_transaction.go
@@ -365,10 +365,6 @@ func (tx AccountAllowanceApproveTransaction) getMethod(channel *_Channel) _Metho
 	}
 }
 
-func (tx AccountAllowanceApproveTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx AccountAllowanceApproveTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/account_allowance_delete_transaction.go
+++ b/sdk/account_allowance_delete_transaction.go
@@ -179,10 +179,6 @@ func (tx AccountAllowanceDeleteTransaction) getMethod(channel *_Channel) _Method
 	}
 }
 
-func (tx AccountAllowanceDeleteTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx AccountAllowanceDeleteTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/account_create_transaction.go
+++ b/sdk/account_create_transaction.go
@@ -458,10 +458,6 @@ func (tx AccountCreateTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx AccountCreateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx AccountCreateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/account_delete_transaction.go
+++ b/sdk/account_delete_transaction.go
@@ -131,10 +131,6 @@ func (tx AccountDeleteTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx AccountDeleteTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx AccountDeleteTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, tx)
 }

--- a/sdk/account_update_transaction.go
+++ b/sdk/account_update_transaction.go
@@ -459,10 +459,6 @@ func (tx AccountUpdateTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx AccountUpdateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx AccountUpdateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/batch_transaction.go
+++ b/sdk/batch_transaction.go
@@ -233,10 +233,6 @@ func (tx BatchTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx BatchTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx BatchTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/contract_create_transaction.go
+++ b/sdk/contract_create_transaction.go
@@ -451,10 +451,6 @@ func (tx ContractCreateTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx ContractCreateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx ContractCreateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/contract_delete_transaction.go
+++ b/sdk/contract_delete_transaction.go
@@ -185,10 +185,6 @@ func (tx ContractDeleteTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx ContractDeleteTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx ContractDeleteTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/contract_execute_transaction.go
+++ b/sdk/contract_execute_transaction.go
@@ -163,10 +163,6 @@ func (tx ContractExecuteTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx ContractExecuteTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx ContractExecuteTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/contract_update_transaction.go
+++ b/sdk/contract_update_transaction.go
@@ -501,10 +501,6 @@ func (tx ContractUpdateTransaction) getMethod(channel *_Channel) _Method {
 		transaction: channel._GetContract().UpdateContract,
 	}
 }
-func (tx ContractUpdateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx ContractUpdateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/ethereum_transaction.go
+++ b/sdk/ethereum_transaction.go
@@ -167,10 +167,6 @@ func (tx EthereumTransaction) buildProtoBody() *services.EthereumTransactionBody
 	return body
 }
 
-func (tx EthereumTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx EthereumTransaction) getMethod(channel *_Channel) _Method {
 	return _Method{
 		transaction: channel._GetContract().CallEthereum,

--- a/sdk/file_append_transaction.go
+++ b/sdk/file_append_transaction.go
@@ -282,11 +282,6 @@ func (tx FileAppendTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-// TODO can be removed at some point
-func (tx FileAppendTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx FileAppendTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/file_create_transaction.go
+++ b/sdk/file_create_transaction.go
@@ -190,10 +190,6 @@ func (tx FileCreateTransaction) getMethod(channel *_Channel) _Method {
 		transaction: channel._GetFile().CreateFile,
 	}
 }
-func (tx FileCreateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx FileCreateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, tx)
 }

--- a/sdk/file_delete_transaction.go
+++ b/sdk/file_delete_transaction.go
@@ -106,10 +106,6 @@ func (tx FileDeleteTransaction) getMethod(channel *_Channel) _Method {
 		transaction: channel._GetFile().DeleteFile,
 	}
 }
-func (tx FileDeleteTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx FileDeleteTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/file_update_transaction.go
+++ b/sdk/file_update_transaction.go
@@ -212,10 +212,6 @@ func (tx FileUpdateTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx FileUpdateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx FileUpdateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/freeze_transaction.go
+++ b/sdk/freeze_transaction.go
@@ -129,10 +129,6 @@ func (tx FreezeTransaction) getMethod(channel *_Channel) _Method {
 		transaction: channel._GetFreeze().Freeze,
 	}
 }
-func (tx FreezeTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx FreezeTransaction) validateNetworkOnIDs(client *Client) error {
 	return nil
 }

--- a/sdk/hook_store_transaction.go
+++ b/sdk/hook_store_transaction.go
@@ -117,10 +117,6 @@ func (tx HookStoreTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx HookStoreTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx HookStoreTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/hook_store_transaction_unit_test.go
+++ b/sdk/hook_store_transaction_unit_test.go
@@ -342,18 +342,6 @@ func TestUnitHookStoreTransactionBuildScheduled(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot schedule `HookStoreTransaction`")
 }
 
-func TestUnitHookStoreTransactionConstructScheduleProtobuf(t *testing.T) {
-	t.Parallel()
-
-	tx := NewHookStoreTransaction()
-
-	scheduled, err := tx.constructScheduleProtobuf()
-
-	assert.Nil(t, scheduled)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot schedule `HookStoreTransaction`")
-}
-
 func TestUnitHookStoreTransactionFromProtobuf(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/live_hash_add_transaction.go
+++ b/sdk/live_hash_add_transaction.go
@@ -208,10 +208,6 @@ func (tx LiveHashAddTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx LiveHashAddTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx LiveHashAddTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/live_hash_delete_transaction.go
+++ b/sdk/live_hash_delete_transaction.go
@@ -122,10 +122,6 @@ func (tx LiveHashDeleteTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx LiveHashDeleteTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx LiveHashDeleteTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/node_create_transaction.go
+++ b/sdk/node_create_transaction.go
@@ -366,10 +366,6 @@ func (tx NodeCreateTransaction) validateTransactionFields() error {
 	return nil
 }
 
-func (tx NodeCreateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx NodeCreateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/node_delete_transaction.go
+++ b/sdk/node_delete_transaction.go
@@ -112,10 +112,6 @@ func (tx NodeDeleteTransaction) validateTransactionFields() error {
 	return nil
 }
 
-func (tx NodeDeleteTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx NodeDeleteTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/node_update_transaction.go
+++ b/sdk/node_update_transaction.go
@@ -447,10 +447,6 @@ func (tx NodeUpdateTransaction) validateTransactionFields() error {
 	return nil
 }
 
-func (tx NodeUpdateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx NodeUpdateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/prng_transaction.go
+++ b/sdk/prng_transaction.go
@@ -83,10 +83,6 @@ func (tx PrngTransaction) getMethod(channel *_Channel) _Method {
 		transaction: channel._GetUtil().Prng,
 	}
 }
-func (tx PrngTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx PrngTransaction) validateNetworkOnIDs(client *Client) error {
 	return nil
 }

--- a/sdk/registered_node_create_transaction.go
+++ b/sdk/registered_node_create_transaction.go
@@ -145,10 +145,6 @@ func (tx RegisteredNodeCreateTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx RegisteredNodeCreateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx RegisteredNodeCreateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/registered_node_create_transaction_unit_test.go
+++ b/sdk/registered_node_create_transaction_unit_test.go
@@ -179,10 +179,6 @@ func TestUnitRegisteredNodeCreateTransactionScheduledBuild(t *testing.T) {
 	scheduled, err := tx.buildScheduled()
 	require.NoError(t, err)
 	require.NotNil(t, scheduled.GetRegisteredNodeCreate())
-
-	again, err := tx.constructScheduleProtobuf()
-	require.NoError(t, err)
-	require.NotNil(t, again.GetRegisteredNodeCreate())
 }
 
 func buildFrozenRegisteredNodeCreateTransaction(t *testing.T) (*RegisteredNodeCreateTransaction, *Client, PrivateKey) {

--- a/sdk/registered_node_delete_transaction.go
+++ b/sdk/registered_node_delete_transaction.go
@@ -99,10 +99,6 @@ func (tx RegisteredNodeDeleteTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx RegisteredNodeDeleteTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx RegisteredNodeDeleteTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/registered_node_delete_transaction_unit_test.go
+++ b/sdk/registered_node_delete_transaction_unit_test.go
@@ -279,12 +279,12 @@ func TestUnitRegisteredNodeDeleteTransactionFromToBytes(t *testing.T) {
 	assert.Equal(t, tx.buildProtoBody(), txFromBytes.(RegisteredNodeDeleteTransaction).buildProtoBody())
 }
 
-func TestUnitRegisteredNodeDeleteTransactionScheduleProtobuf(t *testing.T) {
+func TestUnitRegisteredNodeDeleteTransactionBuildScheduled(t *testing.T) {
 	t.Parallel()
 
 	tx := NewRegisteredNodeDeleteTransaction().SetRegisteredNodeId(7)
 
-	scheduled, err := tx.constructScheduleProtobuf()
+	scheduled, err := tx.buildScheduled()
 	require.NoError(t, err)
 	require.NotNil(t, scheduled.GetRegisteredNodeDelete())
 }

--- a/sdk/registered_node_update_transaction.go
+++ b/sdk/registered_node_update_transaction.go
@@ -181,10 +181,6 @@ func (tx RegisteredNodeUpdateTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx RegisteredNodeUpdateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx RegisteredNodeUpdateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/registered_node_update_transaction_unit_test.go
+++ b/sdk/registered_node_update_transaction_unit_test.go
@@ -387,14 +387,14 @@ func TestUnitRegisteredNodeUpdateTransactionSetServiceEndpoints(t *testing.T) {
 	require.Len(t, body.ServiceEndpoint, 1)
 }
 
-func TestUnitRegisteredNodeUpdateTransactionScheduleProtobuf(t *testing.T) {
+func TestUnitRegisteredNodeUpdateTransactionBuildScheduled(t *testing.T) {
 	t.Parallel()
 
 	tx := NewRegisteredNodeUpdateTransaction().
 		SetRegisteredNodeId(7).
 		SetDescription("scheduled")
 
-	scheduled, err := tx.constructScheduleProtobuf()
+	scheduled, err := tx.buildScheduled()
 	require.NoError(t, err)
 	require.NotNil(t, scheduled.GetRegisteredNodeUpdate())
 }

--- a/sdk/schedule_create_transaction.go
+++ b/sdk/schedule_create_transaction.go
@@ -166,7 +166,7 @@ func (tx *ScheduleCreateTransaction) GetScheduleMemo() string {
 func (tx *ScheduleCreateTransaction) SetScheduledTransaction(scheduledTx TransactionInterface) (*ScheduleCreateTransaction, error) {
 	tx._RequireNotFrozen()
 
-	scheduled, err := scheduledTx.constructScheduleProtobuf()
+	scheduled, err := scheduledTx.buildScheduled()
 	if err != nil {
 		return tx, err
 	}
@@ -240,10 +240,6 @@ func (tx ScheduleCreateTransaction) getMethod(channel *_Channel) _Method {
 	return _Method{
 		transaction: channel._GetSchedule().CreateSchedule,
 	}
-}
-
-func (tx ScheduleCreateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
 }
 
 func (tx ScheduleCreateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {

--- a/sdk/schedule_delete_transaction.go
+++ b/sdk/schedule_delete_transaction.go
@@ -102,10 +102,6 @@ func (tx ScheduleDeleteTransaction) getMethod(channel *_Channel) _Method {
 		transaction: channel._GetSchedule().DeleteSchedule,
 	}
 }
-func (tx ScheduleDeleteTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx ScheduleDeleteTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/schedule_sign_transaction.go
+++ b/sdk/schedule_sign_transaction.go
@@ -111,10 +111,6 @@ func (tx ScheduleSignTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx ScheduleSignTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx ScheduleSignTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/system_delete_transaction.go
+++ b/sdk/system_delete_transaction.go
@@ -188,10 +188,6 @@ func (tx SystemDeleteTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx SystemDeleteTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx SystemDeleteTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/system_undelete_transaction.go
+++ b/sdk/system_undelete_transaction.go
@@ -155,10 +155,6 @@ func (tx SystemUndeleteTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx SystemUndeleteTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx SystemUndeleteTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_airdrop_transaction.go
+++ b/sdk/token_airdrop_transaction.go
@@ -458,10 +458,6 @@ func (tx TokenAirdropTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenAirdropTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenAirdropTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_associate_transaction.go
+++ b/sdk/token_associate_transaction.go
@@ -186,10 +186,6 @@ func (tx TokenAssociateTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenAssociateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenAssociateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_burn_transaction.go
+++ b/sdk/token_burn_transaction.go
@@ -167,10 +167,6 @@ func (tx TokenBurnTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenBurnTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenBurnTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_cancel_airdrop_transaction.go
+++ b/sdk/token_cancel_airdrop_transaction.go
@@ -127,10 +127,6 @@ func (tx TokenCancelAirdropTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenCancelAirdropTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenCancelAirdropTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_claim_airdrop_transaction.go
+++ b/sdk/token_claim_airdrop_transaction.go
@@ -126,10 +126,6 @@ func (tx TokenClaimAirdropTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenClaimAirdropTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenClaimAirdropTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, tx)
 }

--- a/sdk/token_create_transaction.go
+++ b/sdk/token_create_transaction.go
@@ -653,10 +653,6 @@ func (tx TokenCreateTransaction) preFreezeWith(client *Client, self TransactionI
 	}
 }
 
-func (tx TokenCreateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenCreateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_delete_transaction.go
+++ b/sdk/token_delete_transaction.go
@@ -109,10 +109,6 @@ func (tx TokenDeleteTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenDeleteTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenDeleteTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_dissociate_transaction.go
+++ b/sdk/token_dissociate_transaction.go
@@ -180,10 +180,6 @@ func (tx TokenDissociateTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenDissociateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenDissociateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_fee_schedule_update_transaction.go
+++ b/sdk/token_fee_schedule_update_transaction.go
@@ -147,10 +147,6 @@ func (tx TokenFeeScheduleUpdateTransaction) getMethod(channel *_Channel) _Method
 	}
 }
 
-func (tx TokenFeeScheduleUpdateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenFeeScheduleUpdateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_freeze_transaction.go
+++ b/sdk/token_freeze_transaction.go
@@ -148,10 +148,6 @@ func (tx TokenFreezeTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenFreezeTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenFreezeTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_grant_kyc_transaction.go
+++ b/sdk/token_grant_kyc_transaction.go
@@ -146,10 +146,6 @@ func (tx TokenGrantKycTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenGrantKycTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenGrantKycTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_mint_transaction.go
+++ b/sdk/token_mint_transaction.go
@@ -161,10 +161,6 @@ func (tx TokenMintTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenMintTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenMintTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_pause_transaction.go
+++ b/sdk/token_pause_transaction.go
@@ -113,10 +113,6 @@ func (tx TokenPauseTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenPauseTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenPauseTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_reject_transaction.go
+++ b/sdk/token_reject_transaction.go
@@ -197,10 +197,6 @@ func (tx TokenRejectTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenRejectTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenRejectTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_revoke_kyc_transaction.go
+++ b/sdk/token_revoke_kyc_transaction.go
@@ -146,10 +146,6 @@ func (tx TokenRevokeKycTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenRevokeKycTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenRevokeKycTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_unfreeze_transaction.go
+++ b/sdk/token_unfreeze_transaction.go
@@ -149,10 +149,6 @@ func (tx TokenUnfreezeTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenUnfreezeTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenUnfreezeTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_unpause_transaction.go
+++ b/sdk/token_unpause_transaction.go
@@ -111,10 +111,6 @@ func (tx TokenUnpauseTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenUnpauseTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenUnpauseTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_update_nfts_transaction.go
+++ b/sdk/token_update_nfts_transaction.go
@@ -129,10 +129,6 @@ func (tx TokenUpdateNfts) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenUpdateNfts) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenUpdateNfts) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_update_transaction.go
+++ b/sdk/token_update_transaction.go
@@ -566,10 +566,6 @@ func (tx TokenUpdateTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenUpdateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenUpdateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/token_wipe_transaction.go
+++ b/sdk/token_wipe_transaction.go
@@ -198,10 +198,6 @@ func (tx TokenWipeTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TokenWipeTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TokenWipeTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/topic_create_transaction.go
+++ b/sdk/topic_create_transaction.go
@@ -323,10 +323,6 @@ func (tx TopicCreateTransaction) preFreezeWith(client *Client, self TransactionI
 	}
 }
 
-func (tx TopicCreateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TopicCreateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/topic_delete_transaction.go
+++ b/sdk/topic_delete_transaction.go
@@ -100,10 +100,6 @@ func (tx TopicDeleteTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TopicDeleteTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TopicDeleteTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/topic_message_submit_transaction.go
+++ b/sdk/topic_message_submit_transaction.go
@@ -330,10 +330,6 @@ func (tx TopicMessageSubmitTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TopicMessageSubmitTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TopicMessageSubmitTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/topic_update_transaction.go
+++ b/sdk/topic_update_transaction.go
@@ -404,10 +404,6 @@ func (tx TopicUpdateTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TopicUpdateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TopicUpdateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
 }

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -27,11 +27,10 @@ type TransactionInterface interface {
 	regenerateID(*Client) bool // creates new transaction ID
 
 	// methods implemented by every concrete transaction
-	build() *services.TransactionBody                                         // build a protobuf payload for the transaction
-	buildScheduled() (*services.SchedulableTransactionBody, error)            // builds the protobuf payload for the scheduled transaction
-	preFreezeWith(*Client, TransactionInterface)                              // utility method to set the transaction fields before freezing
-	validateTransactionFields() error                                         // utility method to validate transaction fields
-	constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) // TODO remove this method if possible
+	build() *services.TransactionBody                              // build a protobuf payload for the transaction
+	buildScheduled() (*services.SchedulableTransactionBody, error) // builds the protobuf payload for the scheduled transaction
+	preFreezeWith(*Client, TransactionInterface)                   // utility method to set the transaction fields before freezing
+	validateTransactionFields() error                              // utility method to validate transaction fields
 	// NOTE: Any changes to the baseTransaction returned by getBaseTransaction()
 	// will be reflected in the transaction object
 	getBaseTransaction() *Transaction[TransactionInterface]

--- a/sdk/transfer_transaction.go
+++ b/sdk/transfer_transaction.go
@@ -512,10 +512,6 @@ func (tx TransferTransaction) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (tx TransferTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
-	return tx.buildScheduled()
-}
-
 func (tx TransferTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
 	return castFromConcreteToBaseTransaction(tx.Transaction, tx)
 }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
Resolve two stale TODOs that point at the same dead abstraction. `constructScheduleProtobuf`
was the original builder of `SchedulableTransactionBody`, but
`buildScheduled()` took that job over and every one of the 56 implementations had collapsed
into an identical one-line pass-through. `buildScheduled()` is already on `TransactionInterface`,
so the interface loses nothing and the single caller can call it directly.

* Remove `constructScheduleProtobuf` from `TransactionInterface`
* Delete the 56 one-line implementations across `sdk/*_transaction.go`
* Call `buildScheduled()` directly from `ScheduleCreateTransaction.SetScheduledTransaction`
* Point the four unit tests that referenced the method at `buildScheduled()`, dropping two
  assertions that had become exact duplicates

**Related issue(s)**:

Fixes #1802

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
