### PR TITLE
refactor(tck): clone account balance maps

### DIFF
--- a/tck/methods/account.go
+++ b/tck/methods/account.go
@@ -5,6 +5,7 @@ package methods
 import (
 	"context"
 	"errors"
+	"maps"
 	"strconv"
 	"time"
 
@@ -516,15 +517,8 @@ func (a *AccountService) GetAccountBalance(_ context.Context, params param.GetAc
 		return nil, err
 	}
 
-	tokenBalances := make(map[string]uint64)
-	for tokenID, amount := range balance.Tokens.GetAll() {
-		tokenBalances[tokenID] = amount
-	}
-
-	tokenDecimals := make(map[string]uint64)
-	for tokenID, decimals := range balance.TokenDecimals.GetAll() {
-		tokenDecimals[tokenID] = decimals
-	}
+	tokenBalances := maps.Clone(balance.Tokens.GetAll())
+	tokenDecimals := maps.Clone(balance.TokenDecimals.GetAll())
 
 	return &response.AccountBalanceResponse{
 		Hbar:          strconv.Itoa(int(balance.Hbars.AsTinybar())),


### PR DESCRIPTION
**Description**:


There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.


Use `maps.Clone` for defensive account-balance copies in the TCK methods. 

The returned values are unchanged and the copy intent is explicit.



**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
